### PR TITLE
Directly collect Semantic Scholar papers into SQL database

### DIFF
--- a/paperoni/commands/command_collect_semantic_scholar.py
+++ b/paperoni/commands/command_collect_semantic_scholar.py
@@ -103,32 +103,6 @@ class Collection:
                     "author_link (author_id, link_type, link) VALUES(?, ?, ?)",
                     (author_id, author_link.type, author_link.ref),
                 )
-            # Author affiliation.
-            for affiliation in author.affiliations:
-                # We don't have start and end date, so we check if
-                # affiliation and role are already registered with null dates.
-                if author.role is None:
-                    count = db.count(
-                        "author_affiliation",
-                        "author_id",
-                        "affiliation = ? AND role IS NULL "
-                        "AND start_date IS NULL and end_date IS NULL",
-                        [affiliation],
-                    )
-                else:
-                    count = db.count(
-                        "author_affiliation",
-                        "author_id",
-                        "affiliation = ? AND role = ? "
-                        "AND start_date IS NULL and end_date IS NULL",
-                        (affiliation, author.role),
-                    )
-                if not count:
-                    db.insert(
-                        "author_affiliation",
-                        ("author_id", "affiliation", "role"),
-                        (author_id, affiliation, author.role),
-                    )
         # Venue
         venue = paper.venue
         if venue.name:
@@ -182,7 +156,9 @@ class Collection:
             topic_indices.append(topic_id)
         # paper to author
         for author_position, (author_id, author) in enumerate(author_indices):
-            for affiliation in author.affiliations:
+            # Author affiliations may be empty, but we must still
+            # save paper to author relation.
+            for affiliation in (author.affiliations or [""]):
                 db.modify(
                     "INSERT OR IGNORE INTO paper_author "
                     "(paper_id, author_id, author_position, affiliation) "

--- a/paperoni/commands/command_collect_semantic_scholar.py
+++ b/paperoni/commands/command_collect_semantic_scholar.py
@@ -1,3 +1,4 @@
+import pprint
 from coleo import Option, default, tooled
 
 from ..papers2 import Paper
@@ -22,7 +23,10 @@ class Collection:
             return True
         else:
             return self.db.select_id_from_values(
-                "paper", "paper_id", title=paper.title, abstract=paper.abstract
+                "paper",
+                "paper_id",
+                paper_id=self._find_paper_id(paper),
+                excluded=0
             )
 
     def add(self, paper: Paper):
@@ -36,46 +40,69 @@ class Collection:
         self.papers_excluded.add(paper)
 
     def excludes(self, paper: Paper):
-        return paper in self.papers_excluded
+        return paper in self.papers_excluded or self.db.select_id_from_values(
+            "paper",
+            "paper_id",
+            paper_id=self._find_paper_id(paper),
+            excluded=1,
+        )
 
     def save(self):
-        # Delete excluded papers.
-        for paper in self.papers_excluded:
-            if paper.abstract is None:
-                self.db.modify(
-                    "DELETE FROM paper WHERE title = ? AND abstract IS NULL",
-                    [paper.title],
-                )
-            else:
-                self.db.modify(
-                    "DELETE FROM paper WHERE title = ? AND abstract = ?",
-                    (paper.title, paper.abstract),
-                )
-        # Add or update papers.
-        for paper in self.papers_added:
-            self._save_paper(paper)
+        try:
+            # Exclude papers.
+            for paper in self.papers_excluded:
+                self._create_paper_entry(paper, excluded=1)
+            # Add or update papers.
+            for paper in self.papers_added:
+                self._save_paper(paper)
+        except Exception as exc:
+            raise RuntimeError(f"Error saving paper: {pprint.pformat(paper)}") from exc
+
+    def _find_paper_id(self, paper: Paper):
+        # Check paper IDs then title+abstract.
+        for link_type in (
+            "SemanticScholar",
+            "MAG",
+            "ACL",
+            "DBLP",
+            "DOI",
+            "PubMed",
+            "PubMedCentral",
+        ):
+            paper_id = self.db.select_id_from_values(
+                "paper_link",
+                "paper_id",
+                link_type=link_type,
+                link=paper.get_ref(link_type),
+            )
+            if paper_id is not None:
+                return paper_id
+        return self.db.select_id_from_values(
+            "paper", "paper_id", title=paper.title, abstract=paper.abstract
+        )
+
+    def _create_paper_entry(self, paper: Paper, excluded: int = 0) -> int:
+        paper_id = (
+            self._find_paper_id(paper)
+            or self.db.insert(
+                "paper",
+                ("title", "abstract", "citation_count"),
+                (paper.title, paper.abstract, paper.citation_count),
+            )
+        )
+        # Set excluded.
+        self.db.modify(
+            "UPDATE OR IGNORE paper SET excluded = ? WHERE paper_id = ?",
+            (excluded, paper_id),
+        )
+        return paper_id
 
     def _save_paper(self, paper: Paper):
         db = self.db
         author_indices = []
         topic_indices = []
         # Paper: check MAG ID then title+abstract.
-        paper_id = (
-            db.select_id_from_values(
-                "paper_link",
-                "paper_id",
-                link_type="MAG",
-                link=paper.get_ref("MAG"),
-            )
-            or db.select_id_from_values(
-                "paper", "paper_id", title=paper.title, abstract=paper.abstract
-            )
-            or db.insert(
-                "paper",
-                ("title", "abstract", "citation_count"),
-                (paper.title, paper.abstract, paper.citation_count),
-            )
-        )
+        paper_id = self._create_paper_entry(paper, excluded=0)
         # Links
         for link in paper.links:
             if not db.count(
@@ -122,7 +149,10 @@ class Collection:
             # Release
             (release,) = paper.releases
             release_date = None
-            release_year = int(release.year)
+            # NB: Even release.year may be None, so
+            # we set it to an invalid year like -1 000 000,
+            # as we don't expect humans to have written something in such year.
+            release_year = int(release.year) if release.year else -1000000
             volume = venue_volume
             release_id = db.select_id_from_values(
                 "release",
@@ -158,7 +188,7 @@ class Collection:
         for author_position, (author_id, author) in enumerate(author_indices):
             # Author affiliations may be empty, but we must still
             # save paper to author relation.
-            for affiliation in (author.affiliations or [""]):
+            for affiliation in author.affiliations or [""]:
                 db.modify(
                     "INSERT OR IGNORE INTO paper_author "
                     "(paper_id, author_id, author_position, affiliation) "

--- a/paperoni/commands/command_collect_semantic_scholar.py
+++ b/paperoni/commands/command_collect_semantic_scholar.py
@@ -1,0 +1,281 @@
+from coleo import Option, default, tooled
+
+from ..papers2 import Paper
+from .interactive import InteractiveCommands, default_commands
+from .command_semantic_scholar import search
+from ..sql.database import Database
+from ..utils import get_venue_name_and_volume
+
+
+class Collection:
+    __slots__ = ("db", "papers_added", "papers_excluded")
+
+    def __init__(self, filename):
+        self.db = Database(filename)
+        self.papers_added = set()
+        self.papers_excluded = set()
+
+    def __contains__(self, paper: Paper):
+        if paper in self.papers_excluded:
+            return False
+        elif paper in self.papers_added:
+            return True
+        else:
+            return self.db.select_id_from_values(
+                "paper", "paper_id", title=paper.title, abstract=paper.abstract
+            )
+
+    def add(self, paper: Paper):
+        if paper in self.papers_excluded:
+            self.papers_excluded.remove(paper)
+        self.papers_added.add(paper)
+
+    def exclude(self, paper: Paper):
+        if paper in self.papers_added:
+            self.papers_added.remove(paper)
+        self.papers_excluded.add(paper)
+
+    def excludes(self, paper: Paper):
+        return paper in self.papers_excluded
+
+    def save(self):
+        # Delete excluded papers.
+        for paper in self.papers_excluded:
+            if paper.abstract is None:
+                self.db.modify(
+                    "DELETE FROM paper WHERE title = ? AND abstract IS NULL",
+                    [paper.title],
+                )
+            else:
+                self.db.modify(
+                    "DELETE FROM paper WHERE title = ? AND abstract = ?",
+                    (paper.title, paper.abstract),
+                )
+        # Add or update papers.
+        for paper in self.papers_added:
+            self._save_paper(paper)
+
+    def _save_paper(self, paper: Paper):
+        db = self.db
+        author_indices = []
+        topic_indices = []
+        # Paper: check MAG ID then title+abstract.
+        paper_id = (
+            db.select_id_from_values(
+                "paper_link",
+                "paper_id",
+                link_type="MAG",
+                link=paper.get_ref("MAG"),
+            )
+            or db.select_id_from_values(
+                "paper", "paper_id", title=paper.title, abstract=paper.abstract
+            )
+            or db.insert(
+                "paper",
+                ("title", "abstract", "citation_count"),
+                (paper.title, paper.abstract, paper.citation_count),
+            )
+        )
+        # Links
+        for link in paper.links:
+            if not db.count(
+                "paper_link",
+                "paper_id",
+                "link_type = ? AND link = ?",
+                (link.type, link.ref),
+            ):
+                db.insert(
+                    "paper_link",
+                    ("paper_id", "link_type", "link"),
+                    (paper_id, link.type, link.ref),
+                )
+        # Authors
+        for author in paper.authors:
+            # Author
+            author_id = db.select_id(
+                "author", "author_id", "author_name = ?", [author.name]
+            ) or db.insert("author", ["author_name"], [author.name])
+            author_indices.append((author_id, author))
+            # author links
+            for author_link in author.links:
+                db.modify(
+                    "INSERT OR IGNORE INTO "
+                    "author_link (author_id, link_type, link) VALUES(?, ?, ?)",
+                    (author_id, author_link.type, author_link.ref),
+                )
+            # Author affiliation.
+            for affiliation in author.affiliations:
+                # We don't have start and end date, so we check if
+                # affiliation and role are already registered with null dates.
+                if author.role is None:
+                    count = db.count(
+                        "author_affiliation",
+                        "author_id",
+                        "affiliation = ? AND role IS NULL "
+                        "AND start_date IS NULL and end_date IS NULL",
+                        [affiliation],
+                    )
+                else:
+                    count = db.count(
+                        "author_affiliation",
+                        "author_id",
+                        "affiliation = ? AND role = ? "
+                        "AND start_date IS NULL and end_date IS NULL",
+                        (affiliation, author.role),
+                    )
+                if not count:
+                    db.insert(
+                        "author_affiliation",
+                        ("author_id", "affiliation", "role"),
+                        (author_id, affiliation, author.role),
+                    )
+        # Venue
+        venue = paper.venue
+        if venue.name:
+            venue_type = None
+            venue_long_name = venue.name
+            venue_name, venue_volume = get_venue_name_and_volume(
+                venue_long_name
+            )
+            venue_id = db.select_id(
+                "venue",
+                "venue_id",
+                "venue_type IS NULL and venue_name = ?",
+                [venue_name],
+            ) or db.insert(
+                "venue", ("venue_type", "venue_name"), (venue_type, venue_name)
+            )
+            # Release
+            (release,) = paper.releases
+            release_date = None
+            release_year = int(release.year)
+            volume = venue_volume
+            release_id = db.select_id_from_values(
+                "release",
+                "release_id",
+                venue_id=venue_id,
+                release_date=release_date,
+                release_year=release_year,
+                volume=volume,
+            ) or db.insert(
+                "release",
+                ("venue_id", "release_date", "release_year", "volume"),
+                (venue_id, release_date, release_year, volume),
+            )
+            # paper to release
+            if not db.count(
+                "paper_release",
+                "paper_id",
+                "paper_id = ? AND release_id = ?",
+                (paper_id, release_id),
+            ):
+                db.insert(
+                    "paper_release",
+                    ("paper_id", "release_id"),
+                    (paper_id, release_id),
+                )
+        # topics
+        for topic in paper.topics:
+            topic_id = db.select_id(
+                "topic", "topic_id", "topic = ?", [topic.name]
+            ) or db.insert("topic", ["topic"], [topic.name])
+            topic_indices.append(topic_id)
+        # paper to author
+        for author_position, (author_id, author) in enumerate(author_indices):
+            for affiliation in author.affiliations:
+                db.modify(
+                    "INSERT OR IGNORE INTO paper_author "
+                    "(paper_id, author_id, author_position, affiliation) "
+                    "VALUES (?, ?, ?, ?)",
+                    (paper_id, author_id, author_position, affiliation),
+                )
+        # paper to topic
+        for topic_id in topic_indices:
+            db.modify(
+                "INSERT OR IGNORE INTO paper_topic "
+                "(paper_id, topic_id) VALUES (?, ?)",
+                (paper_id, topic_id),
+            )
+
+
+search_commands = InteractiveCommands(
+    "Include this paper in the collection?", default="y"
+)
+
+
+@search_commands.register("y", "[y]es")
+def _y(self, paper, collection: Collection):
+    """Include the paper in the collection"""
+    collection.add(paper)
+    return True
+
+
+@search_commands.register("n", "[n]o")
+def _n(self, paper, collection: Collection):
+    """Exclude the paper from the collection"""
+    collection.exclude(paper)
+    return True
+
+
+@search_commands.register("s", "[s]kip")
+def _s(self, paper, collection: Collection):
+    """Skip and see the next paper"""
+    return True
+
+
+search_commands.update(default_commands)
+
+
+@tooled
+def command_collect_semantic_scholar():
+    """Collect papers from the Microsoft Academic database."""
+
+    # File containing the collection
+    # [alias: -c]
+    collection: Option & Collection
+
+    # Command to run on every paper
+    command: Option = default(None)
+
+    # Prompt for papers even if they were excluded from the collection
+    show_excluded: Option & bool = default(False)
+
+    # Display long form for each paper
+    long: Option & bool = default(False)
+
+    # Update existing papers with new information
+    update: Option & bool = default(False)
+
+    # Include all papers from the collection
+    # [options: --yes]
+    yes_: Option & bool = default(False)
+
+    if yes_:
+        command = "y"
+
+    # Exclude all papers from the collection
+    # [options: --no]
+    no_: Option & bool = default(False)
+
+    if no_:
+        command = "n"
+
+    papers = search()
+
+    for paper in papers:
+        if paper in collection:
+            if update:
+                collection.add(paper)
+            continue
+        if not show_excluded and collection.excludes(paper):
+            continue
+        instruction = search_commands.process_paper(
+            paper,
+            collection=collection,
+            command=command,
+            formatter=Paper.format_term_long if long else Paper.format_term,
+        )
+        if instruction is False:
+            break
+
+    collection.save()

--- a/paperoni/commands/command_import.py
+++ b/paperoni/commands/command_import.py
@@ -154,7 +154,9 @@ def _ms_to_sql(data: dict, db: Database):
         topic_indices.append(topic_id)
     # paper to author
     for author_position, (author_id, author) in enumerate(author_indices):
-        for affiliation in author.affiliations:
+        # Author affiliations may be empty, but we must still
+        # save paper to author relation.
+        for affiliation in (author.affiliations or [""]):
             db.modify(
                 "INSERT OR IGNORE INTO paper_author "
                 "(paper_id, author_id, author_position, affiliation) "

--- a/paperoni/commands/command_import.py
+++ b/paperoni/commands/command_import.py
@@ -25,6 +25,11 @@ def _ms_to_sql(data: dict, db: Database):
     topic_indices = []
     # Paper
     paper_id = db.select_id_from_values(
+        "paper_link",
+        "paper_id",
+        link_type="MAG",
+        link=paper.pid,
+    ) or db.select_id_from_values(
         "paper", "paper_id", title=paper.title, abstract=paper.abstract,
     ) or db.insert(
         "paper", ("title", "abstract"), (paper.title, paper.abstract)
@@ -59,7 +64,12 @@ def _ms_to_sql(data: dict, db: Database):
     # Authors
     for author in paper.authors:
         # Author
-        author_id = db.select_id(
+        author_id = db.select_id_from_values(
+            "author_link",
+            "author_id",
+            link_type="MAG",
+            link=author.aid,
+        ) or db.select_id(
             "author", "author_id", "author_name = ?", [author.name]
         ) or db.insert("author", ["author_name"], [author.name])
         author_indices.append((author_id, author))

--- a/paperoni/commands/command_import.py
+++ b/paperoni/commands/command_import.py
@@ -237,5 +237,3 @@ def command_import():
         enumerate(filtered_ms_papers), total=len(filtered_ms_papers)
     ):
         json_to_sql(paper, db)
-        if verbose and (i + 1) % 10 == 0:
-            print(i + 1, "paper(s) imported.")

--- a/paperoni/commands/command_import.py
+++ b/paperoni/commands/command_import.py
@@ -32,6 +32,20 @@ def _ms_to_sql(data: dict, db: Database):
     ) or db.insert(
         "paper", ("title", "abstract"), (paper.title, paper.abstract)
     )
+    # MAG ID -> paper_link
+    paper_link_type = "mag"
+    paper_link = paper.pid
+    if not db.count(
+        "paper_link",
+        "paper_id",
+        "link_type = ? AND link = ?",
+        (paper_link_type, paper_link),
+    ):
+        db.insert(
+            "paper_link",
+            ("paper_id", "link_type", "link"),
+            (paper_id, paper_link_type, paper_link),
+        )
     # Links
     for link in paper.links:
         if not db.count(

--- a/paperoni/commands/command_semantic_scholar.py
+++ b/paperoni/commands/command_semantic_scholar.py
@@ -1,7 +1,7 @@
 from coleo import Option, default, tooled
 
 from ..papers2 import Paper
-from ..sources.semantic_scholar import SemanticScholarQueryManager
+from .searchutils import search_semantic_scholar as search
 from .interactive import InteractiveCommands, default_commands
 
 search_commands = InteractiveCommands("Enter a command", default="s")
@@ -14,90 +14,6 @@ def _s(self, paper, **_):
 
 
 search_commands.update(default_commands)
-
-
-def _to_microsoft(paper_data: dict):
-    return {
-        "Id": int(paper_data["paperId"], 16),
-        "FamId": paper_data["paperId"],
-        "Y": paper_data["year"],
-        "D": "%04d-01-01" % (paper_data["year"] or 0),
-        "Ti": paper_data["title"],
-        "DN": paper_data["title"],
-        "abstract": paper_data["abstract"],
-        "CC": paper_data["citationCount"],
-        "F": [{"FN": f} for f in (paper_data["fieldsOfStudy"] or ())],
-        "J": {"JN": paper_data["venue"],},
-        "S": [{"Ty": "1", "U": paper_data["url"]}],
-        "VFN": paper_data["venue"],
-        "VSN": paper_data["venue"],
-        "BV": paper_data["venue"],
-        "PB": paper_data["venue"],
-        "AA": [
-            {
-                "AuN": author_dict["name"],
-                "DAuN": author_dict["name"],
-                "AuId": author_dict["authorId"],
-                "DAfN": "",
-            }
-            for author_dict in paper_data["authors"]
-        ],
-    }
-
-
-def join(parts):
-    if parts is None or isinstance(parts, str):
-        return parts
-    else:
-        return " ".join(parts)
-
-
-@tooled
-def search():
-    # [alias: -v]
-    # Verbose output
-    verbose: Option & bool = default(False)
-
-    # [group: search]
-    # [positional: *]
-    # Search for keywords
-    keywords: Option & str = default([])
-    keywords = [join(k) for k in keywords]
-
-    # [group: search]
-    # [alias: -a]
-    # Search by author ID
-    author: Option & str = default("")
-
-    # [group: search]
-    # Number of papers to fetch (default: 100)
-    limit: Option & int = default(100)
-
-    # [group: search]
-    # Search offset
-    offset: Option & int = default(0)
-
-    if author and keywords:
-        raise RuntimeError(
-            "Please specify either keywords or author ID, but not both"
-        )
-    elif not author and not keywords:
-        raise RuntimeError("Keywords or author ID required.")
-
-    qm = SemanticScholarQueryManager()
-    if verbose:
-        print(
-            "[semantic scholar search]",
-            f"keywords: {keywords}," if keywords else f"author ID: {author},",
-            f"limit: {limit}, offset: {offset}",
-        )
-
-    if keywords:
-        papers = qm.search(keywords)
-    else:
-        papers = qm.author_papers(author)
-
-    yield from papers
 
 
 @tooled

--- a/paperoni/commands/searchutils.py
+++ b/paperoni/commands/searchutils.py
@@ -6,6 +6,7 @@ from ..config import get_config
 from ..io import PapersFile, ResearchersFile
 from ..papers import Papers
 from ..query import QueryManager
+from ..sources.semantic_scholar import SemanticScholarQueryManager
 
 
 def _date(x, ending):
@@ -244,3 +245,51 @@ def search(collection=None, researchers=None):
             papers = papers[:limit]
 
     return papers
+
+
+@tooled
+def search_semantic_scholar():
+    # [alias: -v]
+    # Verbose output
+    verbose: Option & bool = default(False)
+
+    # [group: search]
+    # [positional: *]
+    # Search for keywords
+    keywords: Option & str = default([])
+    keywords = [join(k) for k in keywords]
+
+    # [group: search]
+    # [alias: -a]
+    # Search by author ID
+    author: Option & str = default("")
+
+    # [group: search]
+    # Number of papers to fetch (default: 100)
+    limit: Option & int = default(100)
+
+    # [group: search]
+    # Search offset
+    offset: Option & int = default(0)
+
+    if author and keywords:
+        raise RuntimeError(
+            "Please specify either keywords or author ID, but not both"
+        )
+    elif not author and not keywords:
+        raise RuntimeError("Keywords or author ID required.")
+
+    qm = SemanticScholarQueryManager()
+    if verbose:
+        print(
+            "[semantic scholar search]",
+            f"keywords: {keywords}," if keywords else f"author ID: {author},",
+            f"limit: {limit}, offset: {offset}",
+        )
+
+    if keywords:
+        papers = qm.search(keywords)
+    else:
+        papers = qm.author_papers(author)
+
+    yield from papers

--- a/paperoni/papers2.py
+++ b/paperoni/papers2.py
@@ -38,8 +38,7 @@ class Topic:
 class Author:
     links: Sequence[Link] = ()
     name: str = None
-    affiliations: Sequence[str] = ("",)
-    role: str = None
+    affiliations: Sequence[str] = ()
 
 
 @dataclass

--- a/paperoni/papers2.py
+++ b/paperoni/papers2.py
@@ -40,6 +40,13 @@ class Author:
     name: str = None
     affiliations: Sequence[str] = ()
 
+    def get_ref(self, link_type):
+        for link in self.links:
+            if link.type == link_type:
+                return link.ref
+        else:
+            return None
+
 
 @dataclass
 class Venue:

--- a/paperoni/papers2.py
+++ b/paperoni/papers2.py
@@ -38,7 +38,8 @@ class Topic:
 class Author:
     links: Sequence[Link] = ()
     name: str = None
-    affiliations: Sequence[str] = ()
+    affiliations: Sequence[str] = ("",)
+    role: str = None
 
 
 @dataclass
@@ -70,6 +71,9 @@ class Paper:
     releases: Sequence[Release] = ()
     topics: Sequence[Topic] = ()
     citation_count: int = None
+
+    def __hash__(self):
+        return hash((self.title, self.abstract))
 
     @property
     def date(self):
@@ -120,3 +124,10 @@ class Paper:
                 print(f"  {T.bold_green(fmt)} {url}")
 
         print_field("Citations", self.citation_count)
+
+    def get_ref(self, link_type):
+        for link in self.links:
+            if link.type == link_type:
+                return link.ref
+        else:
+            return None

--- a/paperoni/sources/semantic_scholar.py
+++ b/paperoni/sources/semantic_scholar.py
@@ -134,7 +134,9 @@ class SemanticScholarQueryManager:
             title=data["title"],
             abstract=data["abstract"],
             citation_count=data["citationCount"],
-            topics=[Topic(name=field) for field in data["fieldsOfStudy"]],
+            topics=[
+                Topic(name=field) for field in (data["fieldsOfStudy"] or ())
+            ],
             releases=[release],
         )
 
@@ -171,6 +173,7 @@ class SemanticScholarQueryManager:
         yield from self._list(f"author/{author_id}", fields=fields, **params)
 
     def author_papers(self, author_id, fields=AUTHOR_PAPERS_FIELDS, **params):
-        yield from self._list(
+        papers = self._list(
             f"author/{author_id}/papers", fields=fields, **params
         )
+        yield from map(self._wrap_paper, papers)

--- a/paperoni/sql/database.py
+++ b/paperoni/sql/database.py
@@ -59,9 +59,49 @@ class Database:
                 f"Found {len(results)} entries for {table}.{column}"
             )
 
+    def select_id_from_values(self, table, column, **values):
+        where_pieces = []
+        where_parameters = []
+        for key, value in values.items():
+            if value is None:
+                where_pieces.append(f"{key} IS NULL")
+            else:
+                where_pieces.append(f"{key} = ?")
+                where_parameters.append(value)
+        where_query = " AND ".join(where_pieces)
+        self.cursor.execute(
+            f"SELECT {column} FROM {table} WHERE {where_query}",
+            where_parameters,
+        )
+        results = self.cursor.fetchall()
+        if len(results) == 0:
+            return None
+        elif len(results) == 1:
+            return results[0][0]
+        else:
+            raise RuntimeError(
+                f"Found {len(results)} entries for {table}.{column}"
+            )
+
     def count(self, table, column, where_query, where_parameters=()):
         """Select and return count from a table."""
         assert None not in where_parameters
+        self.cursor.execute(
+            f"SELECT COUNT({column}) FROM {table} WHERE {where_query}",
+            where_parameters,
+        )
+        return self.cursor.fetchone()[0]
+
+    def count_from_values(self, table, column, **values):
+        where_pieces = []
+        where_parameters = []
+        for key, value in values.items():
+            if value is None:
+                where_pieces.append(f"{key} IS NULL")
+            else:
+                where_pieces.append(f"{key} = ?")
+                where_parameters.append(value)
+        where_query = " AND ".join(where_pieces)
         self.cursor.execute(
             f"SELECT COUNT({column}) FROM {table} WHERE {where_query}",
             where_parameters,

--- a/paperoni/sql/database.sql
+++ b/paperoni/sql/database.sql
@@ -4,7 +4,9 @@ CREATE TABLE IF NOT EXISTS paper (
 	paper_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	title TEXT,
 	abstract TEXT,
-	citation_count INTEGER
+	citation_count INTEGER,
+	excluded INTEGER NOT NULL DEFAULT 0,
+	CHECK (excluded in (0, 1))
 );
 
 CREATE TABLE IF NOT EXISTS paper_link (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ collect = "paperoni.commands.command_collect:command_collect"
 html = "paperoni.commands.command_html:command_html"
 semantic-scholar = "paperoni.commands.command_semantic_scholar:command_semantic_scholar"
 import = "paperoni.commands.command_import:command_import"
+collect-semantic-scholar = "paperoni.commands.command_collect_semantic_scholar:command_collect_semantic_scholar"
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION
Hi @breuleux this is a PR to collect Semantic Scholar papers into SQL database.

I also check if MAG ID for new paper already exists in database. Tested with following commands:

```
# Import some papers from an author
paperoni import -j ~/Téléchargements/mila-papers.json -c tests/example.db -v -a "Junyoung Chung"

# After found a MAG ID for a paper in database, get related authors IDs in Semantic Scholar:
https://api.semanticscholar.org/graph/v1/paper/MAG:2950067852?fields=authors,title

# Then collect papers from Semantic Scholar for a chosen author:
paperoni collect-semantic-scholar -a 8270717 -c tests/example.db

# Papers collected with existing MAG ID In database should not be duplicated in `paper` table.
```

NB: In `paper_link` table, column `link_type` now contains `MAG` (uppercase) instead of previous `mag` (lowercase) for all MAG IDs (including ones imported from JSON), to match Semantic Scholar nomenclature. You may need to rebuild the database to apply this change.

What do you think?