### PR TITLE
PAP-142: Logger les modifications de la base de données dans sentry.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,3 +8,5 @@ sentry:
   dsn: ""
   traces_sample_rate: 1.0
   environment: dev
+  log_level: INFO
+  event_log_level: INFO

--- a/paperoni/webapp/__init__.py
+++ b/paperoni/webapp/__init__.py
@@ -1,12 +1,23 @@
+import logging
+
 from .common import config
 
 cfg = config()
 
 if hasattr(cfg, "sentry") and cfg.sentry.use:
     import sentry_sdk
+    # Configure sentry to collect log events with minimal level INFO
+    # (2023/10/25) https://docs.sentry.io/platforms/python/integrations/logging/
+    from sentry_sdk.integrations.logging import LoggingIntegration
 
     sentry_sdk.init(
         dsn=cfg.sentry.dsn,
         traces_sample_rate=cfg.sentry.traces_sample_rate,
         environment=cfg.sentry.environment,
+        integrations=[
+            LoggingIntegration(
+                level=logging.INFO,
+                event_level=logging.INFO
+            )
+        ]
     )

--- a/paperoni/webapp/__init__.py
+++ b/paperoni/webapp/__init__.py
@@ -2,6 +2,12 @@ import logging
 
 from .common import config
 
+
+def _get_level(level_name: str) -> int:
+    level = logging.getLevelName(level_name)
+    return level if isinstance(level, int) else logging.INFO
+
+
 cfg = config()
 
 if hasattr(cfg, "sentry") and cfg.sentry.use:
@@ -16,8 +22,8 @@ if hasattr(cfg, "sentry") and cfg.sentry.use:
         environment=cfg.sentry.environment,
         integrations=[
             LoggingIntegration(
-                level=logging.INFO,
-                event_level=logging.INFO
+                level=_get_level(cfg.sentry.log_level),
+                event_level=_get_level(cfg.sentry.event_log_level)
             )
         ]
     )

--- a/paperoni/webapp/render.py
+++ b/paperoni/webapp/render.py
@@ -51,7 +51,9 @@ def author_html(auth):
 
 
 def validation_html(paper, maxauth=50):
-    low_confidence = getattr(config().tweaks, "low_confidence_authors")
+    # It seems config.tweaks is a dictionary, not an object.
+    # So, we must get "low_confidence_authors" as a key, not as an attribute.
+    low_confidence = config().tweaks.get("low_confidence_authors", ())
     c = Confidence(
         institution_name=r".*\bmila\b.*|.*montr.al institute.*learning algorithm.*",
         boost_link_type="wpid_en",


### PR DESCRIPTION
Salut @satyaog ! Voici une PR pour PAP-142. Qu'en penses-tu?

Voilà un exemple de ce que ça m'affiche dans sentry (j'ai créé un projet de test pour observer les logs):

<details>

![Screenshot 2023-10-25 at 09-27-12 Issues — steven-bocco — Sentry](https://github.com/mila-iqia/paperoni/assets/3467054/ab31abed-4f98-4176-933f-b5f4ade38d83)

</details>