### PR TITLE
Improve the JSON export to be more directly useful

### DIFF
--- a/paperoni/db/model_export.py
+++ b/paperoni/db/model_export.py
@@ -1,3 +1,5 @@
+# NOTE: currently unused
+
 from ovld import ovld
 
 from .. import model as M

--- a/paperoni/display.py
+++ b/paperoni/display.py
@@ -87,7 +87,7 @@ def expand_links_dict(links):
         else:
             results.append({"type": link.type, "link": link.link})
     results.sort(
-        key=lambda pair: pref.index(pair["type"]) if pair["type"] in pref else 1
+        key=lambda dct: pref.index(dct["type"]) if dct["type"] in pref else 1
     )
     return results
 

--- a/paperoni/display.py
+++ b/paperoni/display.py
@@ -7,6 +7,7 @@ from blessed import Terminal
 from hrepr import H
 from ovld import ovld
 
+from .cli_helper import ExtendAttr
 from .db import schema as sch
 from .model import Author, DatePrecision, Paper, Venue, from_dict
 
@@ -104,7 +105,7 @@ def display(d: dict):
 
 
 @ovld
-def display(paper: Union[Paper, sch.Paper]):
+def display(paper: Union[Paper, sch.Paper, ExtendAttr]):
     """Print the paper in long form on the terminal.
 
     Long form includes abstract, affiliations, keywords, number of

--- a/paperoni/display.py
+++ b/paperoni/display.py
@@ -50,7 +50,7 @@ def print_field(title, contents, bold=False):
     print(title, contents)
 
 
-def expand_links(links):
+def expand_links_dict(links):
     pref = [
         "doi.abstract",
         "mlr.abstract",
@@ -76,13 +76,26 @@ def expand_links(links):
     for link in links:
         if link.type in link_generators:
             results.extend(
-                (f"{link.type}.{kind}", url.format(link.link))
+                {
+                    "type": f"{link.type}.{kind}",
+                    "link": link.link,
+                    "url": url.format(link.link),
+                }
                 for kind, url in link_generators[link.type].items()
             )
         else:
-            results.append((link.type, link.link))
-    results.sort(key=lambda pair: pref.index(pair[0]) if pair[0] in pref else 1)
+            results.append({"type": link.type, "link": link.link})
+    results.sort(
+        key=lambda pair: pref.index(pair["type"]) if pair["type"] in pref else 1
+    )
     return results
+
+
+def expand_links(links):
+    return [
+        (x["type"], x.get("url", None) or x["link"])
+        for x in expand_links_dict(links)
+    ]
 
 
 @ovld

--- a/paperoni/export.py
+++ b/paperoni/export.py
@@ -1,0 +1,99 @@
+from ovld import ovld
+
+from .db import schema as sch
+from .display import expand_links
+from .model import DatePrecision
+from .utils import peer_reviewed_release
+
+
+def sort_releases(releases):
+    releases = [
+        (release, peer_reviewed_release(release)) for release in releases
+    ]
+    releases.sort(key=lambda entry: -int(entry[1]))
+    return releases
+
+
+@ovld
+def export(paper: sch.Paper):
+    return {
+        "__type__": "Paper",
+        "id": paper.paper_id.hex(),
+        "title": paper.title,
+        "abstract": paper.abstract,
+        "authors": [export(author) for author in paper.authors],
+        "releases": [
+            export(*release) for release in sort_releases(paper.releases)
+        ],
+        "topics": [export(topic) for topic in paper.topics],
+        "links": [
+            {"type": type, "url": url}
+            for type, url in expand_links(paper.links)
+        ],
+        "citation_count": 0,
+    }
+
+
+@ovld
+def export(paper_author: sch.PaperAuthor):
+    return {
+        "author": export(paper_author.author),
+        "affiliations": [export(aff) for aff in paper_author.affiliations],
+    }
+
+
+@ovld
+def export(institution: sch.Institution):
+    return {
+        "id": institution.institution_id.hex(),
+        "name": institution.name,
+        "category": institution.category,
+    }
+
+
+@ovld
+def export(author: sch.Author):
+    return {
+        "id": author.author_id.hex(),
+        "name": author.name,
+        "links": [export(lnk) for lnk in author.links],
+    }
+
+
+@ovld
+def export(link: (sch.PaperLink, sch.AuthorLink, sch.VenueLink)):
+    return {
+        "type": link.type,
+        "link": link.link,
+    }
+
+
+@ovld
+def export(topic: sch.Topic):
+    return {
+        "name": topic.name,
+    }
+
+
+@ovld
+def export(release: sch.Release, peer_reviewed: bool):
+    venue = release.venue
+    return {
+        "venue_id": venue.venue_id.hex(),
+        "name": venue.name,
+        "type": venue.type,
+        "peer_reviewed": peer_reviewed,
+        "date": DatePrecision.format(
+            date=venue.date, precision=venue.date_precision
+        ),
+        "date_timestamp": venue.date,
+        "date_precision": venue.date_precision,
+        "status": release.status,
+        "links": [export(lnk) for lnk in venue.links],
+        "aliases": [a.alias for a in venue.venue_alias],
+        "open": venue.open,
+        "publisher": venue.publisher,
+        "series": venue.series or "",
+        "volume": venue.volume,
+        "pages": release.pages,
+    }

--- a/paperoni/export.py
+++ b/paperoni/export.py
@@ -17,8 +17,7 @@ def sort_releases(releases):
 @ovld
 def export(paper: sch.Paper):
     return {
-        "__type__": "Paper",
-        "id": paper.paper_id.hex(),
+        "paper_id": paper.paper_id.hex(),
         "title": paper.title,
         "abstract": paper.abstract,
         "authors": [export(author) for author in paper.authors],
@@ -45,7 +44,7 @@ def export(paper_author: sch.PaperAuthor):
 @ovld
 def export(institution: sch.Institution):
     return {
-        "id": institution.institution_id.hex(),
+        "institution_id": institution.institution_id.hex(),
         "name": institution.name,
         "category": institution.category,
     }
@@ -54,7 +53,7 @@ def export(institution: sch.Institution):
 @ovld
 def export(author: sch.Author):
     return {
-        "id": author.author_id.hex(),
+        "author_id": author.author_id.hex(),
         "name": author.name,
         "links": [export(lnk) for lnk in author.links],
     }
@@ -77,23 +76,29 @@ def export(topic: sch.Topic):
 
 @ovld
 def export(release: sch.Release, peer_reviewed: bool):
-    venue = release.venue
+    return {
+        "venue": export(release.venue),
+        "peer_reviewed": peer_reviewed,
+        "status": release.status,
+        "pages": release.pages,
+    }
+
+
+@ovld
+def export(venue: sch.Venue):
     return {
         "venue_id": venue.venue_id.hex(),
         "name": venue.name,
         "type": venue.type,
-        "peer_reviewed": peer_reviewed,
-        "date": DatePrecision.format(
-            date=venue.date, precision=venue.date_precision
-        ),
-        "date_timestamp": venue.date,
-        "date_precision": venue.date_precision,
-        "status": release.status,
+        "date": {
+            "text": DatePrecision.format(
+                date=venue.date, precision=venue.date_precision
+            ),
+            "timestamp": venue.date,
+            "precision": venue.date_precision,
+        },
         "links": [export(lnk) for lnk in venue.links],
-        "aliases": [a.alias for a in venue.venue_alias],
-        "open": venue.open,
         "publisher": venue.publisher,
         "series": venue.series or "",
         "volume": venue.volume,
-        "pages": release.pages,
     }

--- a/paperoni/export.py
+++ b/paperoni/export.py
@@ -1,7 +1,7 @@
 from ovld import ovld
 
 from .db import schema as sch
-from .display import expand_links
+from .display import expand_links_dict
 from .model import DatePrecision
 from .utils import peer_reviewed_release
 
@@ -25,10 +25,7 @@ def export(paper: sch.Paper):
             export(*release) for release in sort_releases(paper.releases)
         ],
         "topics": [export(topic) for topic in paper.topics],
-        "links": [
-            {"type": type, "url": url}
-            for type, url in expand_links(paper.links)
-        ],
+        "links": expand_links_dict(paper.links),
         "citation_count": 0,
     }
 

--- a/paperoni/export.py
+++ b/paperoni/export.py
@@ -1,5 +1,6 @@
 from ovld import ovld
 
+from .cli_helper import ExtendAttr
 from .db import schema as sch
 from .display import expand_links_dict
 from .model import DatePrecision
@@ -12,6 +13,14 @@ def sort_releases(releases):
     ]
     releases.sort(key=lambda entry: -int(entry[1]))
     return releases
+
+
+@ovld
+def export(paper: ExtendAttr):
+    return {
+        **export(paper._search_result),
+        "excerpt": getattr(paper, "excerpt", None),
+    }
 
 
 @ovld

--- a/paperoni/utils.py
+++ b/paperoni/utils.py
@@ -309,6 +309,22 @@ def keyword_decorator(deco):
     return new_deco
 
 
+###################
+# Paper utilities #
+###################
+
+
+def peer_reviewed_release(release):
+    name = release.venue.name.lower()
+    return (
+        release.status not in ("submitted", "preprint")
+        and name
+        and name != "n/a"
+        and "workshop" not in name
+        and "rxiv" not in name
+    )
+
+
 ####################
 # Proxying objects #
 ####################

--- a/paperoni/utils.py
+++ b/paperoni/utils.py
@@ -318,7 +318,7 @@ def peer_reviewed_release(release):
     name = release.venue.name.lower()
     return (
         release.status not in ("submitted", "preprint")
-        and name
+        and name.strip() != ""
         and name != "n/a"
         and "workshop" not in name
         and "rxiv" not in name

--- a/paperoni/webapp/common.py
+++ b/paperoni/webapp/common.py
@@ -189,6 +189,7 @@ class SearchElement:
             H.input(
                 name=self.name,
                 type=self.type,
+                autocomplete="off",
                 oninput=queue,
                 value=self.value or False,
             ),

--- a/paperoni/webapp/filters.py
+++ b/paperoni/webapp/filters.py
@@ -1,16 +1,9 @@
+from ..utils import peer_reviewed_release
+
+
 def no_validation_flag(paper):
     return not any(flag.flag_name == "validation" for flag in paper.paper_flag)
 
 
 def peer_reviewed(paper):
-    def peer_reviewed_release(release):
-        name = release.venue.name.lower()
-        return (
-            release.status not in ("submitted", "preprint")
-            and name
-            and name != "n/a"
-            and "workshop" not in name
-            and "rxiv" not in name
-        )
-
     return any(peer_reviewed_release(release) for release in paper.releases)

--- a/paperoni/webapp/report.py
+++ b/paperoni/webapp/report.py
@@ -49,8 +49,6 @@ class JSONFormatter(PaperFormatter):
         return f"{dest}.json"
 
     def process(self, paper):
-        if isinstance(paper, ExtendAttr):
-            paper = paper._search_result
         return json.dumps(export(paper))
 
 

--- a/paperoni/webapp/report.py
+++ b/paperoni/webapp/report.py
@@ -1,9 +1,11 @@
+import json
 from datetime import datetime
 
 from starlette.responses import JSONResponse, StreamingResponse
 
-from ..db.model_export import export
+from ..cli_helper import ExtendAttr
 from ..display import expand_links
+from ..export import export
 from .common import SearchGUI, config
 
 
@@ -47,7 +49,9 @@ class JSONFormatter(PaperFormatter):
         return f"{dest}.json"
 
     def process(self, paper):
-        return export(paper).tagged_json()
+        if isinstance(paper, ExtendAttr):
+            paper = paper._search_result
+        return json.dumps(export(paper))
 
 
 class CSVFormatter(PaperFormatter):


### PR DESCRIPTION
* This export format includes an ID for the paper
* Sorts the paper links and provides explicit URLs
* Sorts the publication venues, with the most important (peer reviewed) venue first
