### PR TITLE
Fix find-author-ids

### DIFF
--- a/paperoni/webapp/author-institution.py
+++ b/paperoni/webapp/author-institution.py
@@ -172,8 +172,8 @@ async def app(page, box):
                 H.div(
                     get_type_links(author, "semantic_scholar"),
                     "⧉",
-                    onclick="window.open('/find-authors-ids?scraper=semantic_scholar&author="
-                    + str(author.name)
+                    onclick="window.open('/find-authors-ids?scraper=semantic_scholar&author_id="
+                    + author.author_id.hex()
                     + "');",
                 )
             ),
@@ -181,8 +181,8 @@ async def app(page, box):
                 H.div(
                     get_type_links(author, "openreview"),
                     "⧉",
-                    onclick="window.open('/find-authors-ids?scraper=openreview&author="
-                    + str(author.name)
+                    onclick="window.open('/find-authors-ids?scraper=openreview&author_id="
+                    + author.author_id.hex()
                     + "');",
                 ),
             ),


### PR DESCRIPTION
The fact that find-author-ids takes the author name rather than the author's database ID complicates things a little when adding new researchers that are already in the authors database, and the styling on the radio buttons doesn't work anymore because of style changes. Now the validation buttons work properly and find-author-ids takes an ID rather than a name; links in the author-institution page are adjusted correspondingly.
