### PR TITLE
Fixes to dash, discovery, tags

### DIFF
--- a/src/paperoni/__main__.py
+++ b/src/paperoni/__main__.py
@@ -257,13 +257,19 @@ class Work:
 class PaperoniInterface:
     """Paper database"""
 
+    # Command to execute
     command: TaggedUnion[Discover, Refine, Fulltext, Work]
 
+    # Enable rich dashboard
+    dash: bool = True
+
     def run(self):
+        if self.dash:
+            enable_dash()
         self.command.run()
 
 
-def main():
+def enable_dash():
     @outsight.add
     async def show_progress(sent, dash):
         async for name, sofar, total in sent["progress"]:
@@ -307,6 +313,8 @@ def main():
             values = [f"{model} {prompt} {input}" for prompt, model, input in group]
             dash["prompt"] = History(values)
 
+
+def main():
     with outsight:
         parser = argparse.ArgumentParser(add_help=False)
         parser.add_argument("--config", default=None)

--- a/src/paperoni/discovery/miniconf.py
+++ b/src/paperoni/discovery/miniconf.py
@@ -134,6 +134,7 @@ class MiniConf(Discoverer):
             links.add(Link(type="pdf", link=url))
         if url := expand_base(data.get("virtualsite_url")):
             links.add(Link(type="abstract", link=url))
+        links.add(Link(type="uid", link=data["uid"]))
 
         # Add eventmedia links
         for media in data.get("eventmedia", []):

--- a/src/paperoni/refinement/dblp.py
+++ b/src/paperoni/refinement/dblp.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date
 from typing import Literal
 
@@ -13,6 +14,17 @@ from ..model import (
     VenueType,
 )
 from .fetch import register_fetch
+
+
+def _clean_author_name(name):
+    return re.sub(r"\s*\d+$", "", name)
+
+
+def _author_links(author_span):
+    links = [Link(type="dblp", link=author_span.text)]
+    if orcid := author_span.attrs.get("orcid"):
+        links.append(Link(type="orcid", link=orcid))
+    return links
 
 
 @register_fetch
@@ -33,14 +45,10 @@ def dblp(type: Literal["dblp"], link: str):
         abstract="",
         authors=[
             PaperAuthor(
-                display_name=author.text,
+                display_name=(name := _clean_author_name(author.text)),
                 author=Author(
-                    name=author.text,
-                    links=(
-                        [Link(type="orcid", link=orcid)]
-                        if (orcid := author.attrs.get("orcid", None))
-                        else []
-                    ),
+                    name=name,
+                    links=_author_links(author),
                 ),
                 affiliations=[],
             )

--- a/src/paperoni/refinement/pdf/model.py
+++ b/src/paperoni/refinement/pdf/model.py
@@ -24,6 +24,10 @@ SYSTEM_MESSAGE = """You are a Deep Learning expert specializing in scientific te
 - Check Completeness:
   - Ensure no author is omitted from the list.
   - Ensure all affiliations are listed correctly for each author.
+- Normalize these affiliation names. The name in quotes is the normalized name that you should use.
+  - "Mila": could be listed as MILA, Montreal Institute for Learning Algorithms, IQIA, Institut Québécois d'Intelligence Artificielle
+  - "Université de Montréal": could be listed in English as University of Montreal, possibly as the shortened UdeM
+- CIFAR AI Chair is not an affiliation. Ignore it.
 
 ### Key Considerations:
 

--- a/tests/discovery/test_jmlr/test_query.yml
+++ b/tests/discovery/test_jmlr/test_query.yml
@@ -41,12 +41,14 @@
       display_name: Xavier Bresson
     flags: []
     links:
-    - link: https://jmlr.org/papers/v24/22-0567.html
-      type: abstract.official
     - link: https://jmlr.org/papers/volume24/22-0567/22-0567.pdf
       type: pdf.official
     - link: https://jmlr.org/papers/v24/22-0567.bib
       type: bibtex
+    - link: https://jmlr.org/papers/v24/22-0567.html
+      type: abstract.official
+    - link: https://jmlr.org/papers/v24/22-0567.html
+      type: uid
     releases:
     - pages: 1-48
       status: published
@@ -109,12 +111,14 @@
       display_name: Emmanuel Bengio
     flags: []
     links:
-    - link: https://jmlr.org/papers/v24/22-0364.html
-      type: abstract.official
     - link: https://jmlr.org/papers/volume24/22-0364/22-0364.pdf
       type: pdf.official
     - link: https://jmlr.org/papers/v24/22-0364.bib
       type: bibtex
+    - link: https://jmlr.org/papers/v24/22-0364.html
+      type: abstract.official
+    - link: https://jmlr.org/papers/v24/22-0364.html
+      type: uid
     releases:
     - pages: 1-55
       status: published

--- a/tests/discovery/test_miniconf/test_query_aistats_query_params8_.yml
+++ b/tests/discovery/test_miniconf/test_query_aistats_query_params8_.yml
@@ -53,6 +53,8 @@
     links:
     - link: https://virtual.aistats.org/virtual/2024/poster/6765
       type: abstract
+    - link: cdf1035c34ec380218a8cc9a43d438f9
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -158,6 +160,8 @@
     links:
     - link: https://virtual.aistats.org/virtual/2024/poster/6934
       type: abstract
+    - link: f2fc990265c712c49d51a18a32b39f0c
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -230,6 +234,8 @@
     links:
     - link: https://virtual.aistats.org/virtual/2024/poster/6683
       type: abstract
+    - link: 2b8a61594b1f4c4db0902a8a395ced93
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -339,6 +345,8 @@
     links:
     - link: https://virtual.aistats.org/virtual/2024/poster/6633
       type: abstract
+    - link: 49b8b4f95f02e055801da3b4f58e28b7
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -420,6 +428,8 @@
     links:
     - link: https://virtual.aistats.org/virtual/2024/poster/6852
       type: abstract
+    - link: 24146db4eb48c718b84cae0a0799dcfc
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)

--- a/tests/discovery/test_miniconf/test_query_aistats_query_params9_.yml
+++ b/tests/discovery/test_miniconf/test_query_aistats_query_params9_.yml
@@ -108,6 +108,8 @@
     links:
     - link: https://virtual.aistats.org/virtual/2024/poster/6691
       type: abstract
+    - link: a760880003e7ddedfef56acb3b09697f
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)

--- a/tests/discovery/test_miniconf/test_query_cvpr_query_params10_.yml
+++ b/tests/discovery/test_miniconf/test_query_cvpr_query_params10_.yml
@@ -53,6 +53,8 @@
       type: abstract
     - link: https://openaccess.thecvf.com/content/CVPR2024/html/Zhang_Contrasting_Intra-Modal_and_Ranking_Cross-Modal_Hard_Negatives_to_Enhance_Visio-Linguistic_CVPR_2024_paper.html
       type: paper_pdf
+    - link: e9dcb63ca828d0e00cd05b445099ed2e
+      type: uid
     releases:
     - pages: null
       status: 'Accept: Poster'
@@ -144,6 +146,8 @@
       type: abstract
     - link: https://openaccess.thecvf.com/content/CVPR2024/html/Zhang_Overcoming_Generic_Knowledge_Loss_with_Selective_Parameter_Update_CVPR_2024_paper.html
       type: paper_pdf
+    - link: 1170017b40d1ba28394ebc44158dae8a
+      type: uid
     releases:
     - pages: null
       status: 'Accept: Poster'

--- a/tests/discovery/test_miniconf/test_query_iclr_query_params4_.yml
+++ b/tests/discovery/test_miniconf/test_query_iclr_query_params4_.yml
@@ -82,6 +82,8 @@
       type: abstract
     - link: ptXo0epLQo
       type: openreview
+    - link: 40dba662fae60cd3bcceaa76a82d2873
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -171,6 +173,8 @@
       type: abstract
     - link: ruGY8v10mK
       type: openreview
+    - link: 6be5336db2c119736cf48f475e051bfe
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -299,6 +303,8 @@
       type: openreview
     - link: https://iclr.cc/media/iclr-2024/Slides/18725.pdf
       type: slides
+    - link: 7f53f8c6c730af6aeb52e66eb74d8507
+      type: uid
     releases:
     - pages: null
       status: Accept (oral)
@@ -413,6 +419,8 @@
       type: openreview
     - link: https://iclr.cc/media/iclr-2024/Slides/18437.pdf
       type: slides
+    - link: 92af93f73faf3cefc129b6bc55a748a9
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -533,6 +541,8 @@
       type: abstract
     - link: ms0VgzSGF2
       type: openreview
+    - link: a9be4c2a4041cadbf9d61ae16dd1389e
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)

--- a/tests/discovery/test_miniconf/test_query_iclr_query_params5_.yml
+++ b/tests/discovery/test_miniconf/test_query_iclr_query_params5_.yml
@@ -106,6 +106,8 @@
       type: openreview
     - link: https://iclr.cc/media/iclr-2024/Slides/18725.pdf
       type: slides
+    - link: 7f53f8c6c730af6aeb52e66eb74d8507
+      type: uid
     releases:
     - pages: null
       status: Accept (oral)
@@ -215,6 +217,8 @@
       type: abstract
     - link: eo9dHwtTFt
       type: openreview
+    - link: 0c0a7566915f4f24853fc4192689aa7e
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -302,6 +306,8 @@
       type: abstract
     - link: f1xnBr4WD6
       type: openreview
+    - link: 1d01bd2e16f57892f0954902899f0692
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -439,6 +445,8 @@
       type: abstract
     - link: LemSSn8htt
       type: openreview
+    - link: 23ad3e314e2a2b43b4c720507cec0723
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -541,6 +549,8 @@
       type: abstract
     - link: OIsahq1UYC
       type: openreview
+    - link: 7d3d5bcad324d3edc08e40738e663554
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)

--- a/tests/discovery/test_miniconf/test_query_icml_query_params2_.yml
+++ b/tests/discovery/test_miniconf/test_query_icml_query_params2_.yml
@@ -89,6 +89,8 @@
       type: pdf
     - link: https://icml.cc/virtual/2024/poster/32732
       type: abstract
+    - link: 989652eef28bc49eec908063ba36a854
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -220,6 +222,8 @@
       type: pdf
     - link: https://icml.cc/virtual/2024/poster/32627
       type: abstract
+    - link: a6155b0da06d1ad154ad2d039d1fadf4
+      type: uid
     releases:
     - pages: null
       status: Accept (Spotlight)
@@ -310,6 +314,8 @@
       type: abstract
     - link: https://icml.cc/media/icml-2024/Slides/33949_ypaq1v1.pdf
       type: slides
+    - link: 285da2198b2b496c9d447cc4ac6b0734
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -431,6 +437,8 @@
       type: pdf
     - link: https://icml.cc/virtual/2024/poster/34245
       type: abstract
+    - link: d465f14a648b3d0a1faa6f447e526c60
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -518,6 +526,8 @@
       type: pdf
     - link: https://icml.cc/virtual/2024/poster/34560
       type: abstract
+    - link: f2c5b1f06bfe59954cb2a56858c2ed98
+      type: uid
     releases:
     - pages: null
       status: Accept (Spotlight)

--- a/tests/discovery/test_miniconf/test_query_icml_query_params3_.yml
+++ b/tests/discovery/test_miniconf/test_query_icml_query_params3_.yml
@@ -84,6 +84,8 @@
       type: pdf
     - link: https://icml.cc/virtual/2024/poster/34356
       type: abstract
+    - link: bb1662b7c5f22a0f905fd59e718ca05e
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -264,6 +266,8 @@
       type: pdf
     - link: https://icml.cc/virtual/2024/poster/33422
       type: abstract
+    - link: 63eb58bd4d3486f001438f911a11d323
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -409,6 +413,8 @@
       type: abstract
     - link: https://icml.cc/media/icml-2024/Slides/34500.pdf
       type: slides
+    - link: 1a6727711b84fd1efbb87fc565199d13
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -506,6 +512,8 @@
       type: pdf
     - link: https://icml.cc/virtual/2024/poster/32689
       type: abstract
+    - link: cf1f78fe923afe05f7597da2be7a3da8
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)
@@ -617,6 +625,8 @@
       type: abstract
     - link: https://jmlr.org/papers/v25/23-0680.html
       type: jmlr
+    - link: f0935e4cd5920aa6c7c996a5ee53a70f
+      type: uid
     releases:
     - pages: null
       status: Accept (Poster)

--- a/tests/discovery/test_miniconf/test_query_neurips_query_params0_.yml
+++ b/tests/discovery/test_miniconf/test_query_neurips_query_params0_.yml
@@ -81,6 +81,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/616521c3cf15f9f7018565c427d40e3b-Abstract-Conference.html
       type: paper
+    - link: eed4435e296d75fa7280539943113a7d
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -185,6 +187,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/55769e1208c7f45e9acc98f06279c10c-Abstract-Conference.html
       type: paper
+    - link: 2f10158c59d8ce7d40687769eb8e0424
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -268,6 +272,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/794a72b1a9d5fc4c040eb3110d94c8a1-Abstract-Conference.html
       type: paper
+    - link: 8d97f450424ddf6448b7efe4159d2aa6
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -488,6 +494,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/8b21a7ea42cbcd1c29a7a88c444cce45-Abstract-Conference.html
       type: paper
+    - link: 6e2d5d50a943a0e0d738377f51011685
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -585,6 +593,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/92f79f493ca2d6c0ba04c3af76bb3368-Abstract-Conference.html
       type: paper
+    - link: 76a271c64a315732aa56eeb7277a63d4
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)

--- a/tests/discovery/test_miniconf/test_query_neurips_query_params1_.yml
+++ b/tests/discovery/test_miniconf/test_query_neurips_query_params1_.yml
@@ -198,6 +198,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/8b21a7ea42cbcd1c29a7a88c444cce45-Abstract-Conference.html
       type: paper
+    - link: 6e2d5d50a943a0e0d738377f51011685
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -345,6 +347,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/93c936b9e492def9c00782cab79dbc6d-Abstract-Conference.html
       type: paper
+    - link: 38811c5285e34e2e3319ab7d9f2cfa5b
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -506,6 +510,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/2318d75a06437eaa257737a5cf3ab83c-Abstract-Conference.html
       type: paper
+    - link: 306b0c0a95972617146049ce1a9a1613
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -658,6 +664,8 @@
       type: paper
     - link: https://neurips.cc/media/neurips-2024/Slides/94040.pdf
       type: slides
+    - link: 2f61bc8be89fcc808b4679e1d5de7c60
+      type: uid
     releases:
     - pages: null
       status: Accept (poster)
@@ -784,6 +792,8 @@
       type: openreview
     - link: https://proceedings.neurips.cc/paper_files/paper/2024/hash/c1e67cde895c3c91edb43569ad0df260-Abstract-Conference.html
       type: paper
+    - link: d9dbc51dc534921589adf460c85cd824
+      type: uid
     releases:
     - pages: null
       status: Accept (spotlight)

--- a/tests/refinement/test_fetch.py
+++ b/tests/refinement/test_fetch.py
@@ -13,14 +13,16 @@ from paperoni.refinement.title import crossref_title, openalex_title
     ["f_tags", "tags", "pass_"],
     [
         (set(), set(), True),
-        (set(), {"*"}, True),
-        (set(), {"a"}, True),
-        ({"a", "b"}, {"*"}, True),
+        (set(), {"all"}, True),
+        (set(), {"a"}, False),
+        ({"a", "b"}, {"all"}, True),
+        ({"a", "b"}, {"a"}, True),
+        ({"a", "b"}, {"b"}, True),
         ({"a", "b"}, {"a", "b"}, True),
         ({"a", "b"}, {"a", "b", "c"}, False),
         ({"a", "b"}, {"a", "c"}, False),
-        ({"a", "b"}, {"a", "c", "*"}, False),
-        ({"a", "b", "c"}, {"a", "b", "c", "*"}, True),
+        ({"a", "b"}, {"a", "c", "all"}, True),
+        ({"a", "b", "c"}, {"a", "b", "c", "all"}, True),
     ],
 )
 def test__test_tags(f_tags, tags, pass_):

--- a/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_aaai_Rezaei_Shoshtari23_.yml
+++ b/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_aaai_Rezaei_Shoshtari23_.yml
@@ -3,31 +3,41 @@ authors:
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Sahand Rezaei-Shoshtari
+      type: dblp
     name: Sahand Rezaei-Shoshtari
   display_name: Sahand Rezaei-Shoshtari
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Charlotte Morissette
+      type: dblp
     name: Charlotte Morissette
   display_name: Charlotte Morissette
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: François Robert Hogan
+      type: dblp
     name: François Robert Hogan
   display_name: François Robert Hogan
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Gregory Dudek
+      type: dblp
     name: Gregory Dudek
   display_name: Gregory Dudek
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: David Meger
+      type: dblp
     name: David Meger
   display_name: David Meger
 flags: []

--- a/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_icml_LachapelleDMMBL23_.yml
+++ b/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_icml_LachapelleDMMBL23_.yml
@@ -3,43 +3,57 @@ authors:
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Sébastien Lachapelle
+      type: dblp
     name: Sébastien Lachapelle
   display_name: Sébastien Lachapelle
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Tristan Deleu
+      type: dblp
     name: Tristan Deleu
   display_name: Tristan Deleu
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Divyat Mahajan
+      type: dblp
     name: Divyat Mahajan
   display_name: Divyat Mahajan
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Ioannis Mitliagkas
+      type: dblp
     name: Ioannis Mitliagkas
   display_name: Ioannis Mitliagkas
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Yoshua Bengio
+      type: dblp
     name: Yoshua Bengio
   display_name: Yoshua Bengio
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Simon Lacoste-Julien
+      type: dblp
     name: Simon Lacoste-Julien
   display_name: Simon Lacoste-Julien
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Quentin Bertrand
+      type: dblp
     name: Quentin Bertrand
   display_name: Quentin Bertrand
 flags: []

--- a/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_icse_chase_AryaGR25_.yml
+++ b/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_icse_chase_AryaGR25_.yml
@@ -3,19 +3,25 @@ authors:
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Deeksha M. Arya
+      type: dblp
     name: Deeksha M. Arya
   display_name: Deeksha M. Arya
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Jin L. C. Guo
+      type: dblp
     name: Jin L. C. Guo
   display_name: Jin L. C. Guo
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Martin P. Robillard
+      type: dblp
     name: Martin P. Robillard
   display_name: Martin P. Robillard
 flags: []

--- a/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_nips_LacosteLRSKLIDA23_.yml
+++ b/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_nips_LacosteLRSKLIDA23_.yml
@@ -3,105 +3,139 @@ authors:
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Alexandre Lacoste
+      type: dblp
     name: Alexandre Lacoste
   display_name: Alexandre Lacoste
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Nils Lehmann
+      type: dblp
     name: Nils Lehmann
   display_name: Nils Lehmann
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Pau Rodríguez
+      type: dblp
     name: Pau Rodríguez
   display_name: Pau Rodríguez
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Evan D. Sherwin
+      type: dblp
     name: Evan D. Sherwin
   display_name: Evan D. Sherwin
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Hannah Kerner
+      type: dblp
     name: Hannah Kerner
   display_name: Hannah Kerner
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Björn Lütjens
+      type: dblp
     name: Björn Lütjens
   display_name: Björn Lütjens
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Jeremy Irvin
+      type: dblp
     name: Jeremy Irvin
   display_name: Jeremy Irvin
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: David Dao
+      type: dblp
     name: David Dao
   display_name: David Dao
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Hamed Alemohammad
+      type: dblp
     name: Hamed Alemohammad
   display_name: Hamed Alemohammad
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Alexandre Drouin
+      type: dblp
     name: Alexandre Drouin
   display_name: Alexandre Drouin
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Mehmet Gunturkun
+      type: dblp
     name: Mehmet Gunturkun
   display_name: Mehmet Gunturkun
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Gabriel Huang
+      type: dblp
     name: Gabriel Huang
   display_name: Gabriel Huang
 - affiliations: []
   author:
     aliases: []
-    links: []
-    name: David Vázquez 0001
-  display_name: David Vázquez 0001
+    links:
+    - link: David Vázquez 0001
+      type: dblp
+    name: David Vázquez
+  display_name: David Vázquez
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Dava J. Newman
+      type: dblp
     name: Dava J. Newman
   display_name: Dava J. Newman
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Yoshua Bengio
+      type: dblp
     name: Yoshua Bengio
   display_name: Yoshua Bengio
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Stefano Ermon
+      type: dblp
     name: Stefano Ermon
   display_name: Stefano Ermon
 - affiliations: []
   author:
     aliases: []
-    links: []
-    name: Xiaoxiang Zhu 0001
-  display_name: Xiaoxiang Zhu 0001
+    links:
+    - link: Xiaoxiang Zhu 0001
+      type: dblp
+    name: Xiaoxiang Zhu
+  display_name: Xiaoxiang Zhu
 flags: []
 links:
 - link: conf/nips/LacosteLRSKLIDA23

--- a/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_wacv_DaultaniL24_.yml
+++ b/tests/refinement/test_fetch/test_refine_dblp_dblp_conf_wacv_DaultaniL24_.yml
@@ -3,13 +3,17 @@ authors:
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Dinesh Daultani
+      type: dblp
     name: Dinesh Daultani
   display_name: Dinesh Daultani
 - affiliations: []
   author:
     aliases: []
-    links: []
+    links:
+    - link: Hugo Larochelle
+      type: dblp
     name: Hugo Larochelle
   display_name: Hugo Larochelle
 flags: []


### PR DESCRIPTION
* Add --no-dash option
* Dash is lazier, it won't do anything at all until something is contributed to it
* Loop through years for miniconf
* Add some uid link objects to some discoverers for better identification
* Clean up author names in dblp