### PR TITLE
Paper merging fix, define more scraping jobs, others

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,5 @@
 web: paperoni serve
-scrape: paperoni --no-dash --rich-log --report batch scrape.yaml
+test: ls -l
+scrape_all: paperoni --no-dash --rich-log --report batch scrape-all.yaml
+scrape_recent: paperoni --no-dash --rich-log --report batch scrape-recent.yaml
+scrape_updates: paperoni --no-dash --rich-log --report batch scrape-updates.yaml

--- a/src/paperoni/__main__.py
+++ b/src/paperoni/__main__.py
@@ -584,7 +584,7 @@ class Work:
                 selected = [replace(p, flags=p.flags | {self.flag}) for p in selected]
 
             try:
-                added = await self._coll(work).add_papers(selected)
+                added = await self._coll(work).add_papers(selected, force=True)
             finally:
                 # As some papers could be added to the collection before an
                 # error is raised, causing a new paper to exists in the

--- a/src/paperoni/model/merge.py
+++ b/src/paperoni/model/merge.py
@@ -41,15 +41,6 @@ def merge(x: object, y: object):
     return recurse(x, y, 0.0, 0.0)
 
 
-@ovld(priority=10)
-def merge(x: object, y: object, qx: Number, qy: Number):
-    if qx <= -10 or qy <= -10 or qx >= 10 or qy >= 10:
-        # We only do piecewise merging if both q are between -10 and 10 exclusive
-        return x if qx >= qy else y
-    else:
-        return call_next(x, y, qx, qy)
-
-
 @ovld
 def merge(x: None, y: object, qx: Number, qy: Number):
     return y
@@ -66,23 +57,25 @@ def merge(x: object, y: object, qx: Number, qy: Number):
     return x if qx >= qy else y
 
 
-@ovld(priority=2)
-def merge(x: CommentProxy, y: CommentProxy, qx: Number, qy: Number):
-    qx = x._
-    qy = y._
-    return qual(recurse(x._obj, y._obj, qx, qy), max(qx, qy))
-
-
-@ovld(priority=1)
+@ovld(priority=3)
 def merge(x: CommentProxy, y: object, qx: Number, qy: Number):
     qx = x._
     return qual(recurse(x._obj, y, qx, qy), max(qx, qy))
 
 
-@ovld
+@ovld(priority=2)
 def merge(x: object, y: CommentProxy, qx: Number, qy: Number):
     qy = y._
     return qual(recurse(x, y._obj, qx, qy), max(qx, qy))
+
+
+@ovld(priority=1)
+def merge(x: object, y: object, qx: Number, qy: Number):
+    if qx <= -10 or qy <= -10 or qx >= 10 or qy >= 10:
+        # We only do piecewise merging if both q are between -10 and 10 exclusive
+        return x if qx >= qy else y
+    else:
+        return call_next(x, y, qx, qy)
 
 
 @ovld

--- a/src/paperoni/model/merge.py
+++ b/src/paperoni/model/merge.py
@@ -66,6 +66,13 @@ def merge(x: object, y: object, qx: Number, qy: Number):
     return x if qx >= qy else y
 
 
+@ovld(priority=2)
+def merge(x: CommentProxy, y: CommentProxy, qx: Number, qy: Number):
+    qx = x._
+    qy = y._
+    return qual(recurse(x._obj, y._obj, qx, qy), max(qx, qy))
+
+
 @ovld(priority=1)
 def merge(x: CommentProxy, y: object, qx: Number, qy: Number):
     qx = x._

--- a/src/paperoni/prompt.py
+++ b/src/paperoni/prompt.py
@@ -73,7 +73,9 @@ def _generate_metadata(
     usage = response.usage_metadata
     if usage is not None:
         input_tokens = usage.prompt_token_count
-        output_tokens = usage.candidates_token_count + usage.thoughts_token_count
+        tk = usage.candidates_token_count or 0
+        ttk = usage.thoughts_token_count or 0
+        output_tokens = tk + ttk
         total_tokens = usage.total_token_count
     else:
         input_tokens = output_tokens = total_tokens = None

--- a/src/paperoni/web/assets/paper.js
+++ b/src/paperoni/web/assets/paper.js
@@ -167,6 +167,8 @@ export function attachAuthorAffiliationHover(container) {
 export function createAuthorsSection(authors, options = {}) {
     const { searchParams = {}, onAuthorClick = null, onInstitutionClick = null } = options;
 
+    const comment = authors?.$comment ?? null;
+
     if (!authors || authors.length === 0) {
         return html`<div class="paper-authors-container"><div class="paper-authors">No authors</div></div>`;
     }
@@ -223,8 +225,13 @@ export function createAuthorsSection(authors, options = {}) {
         ? html`<div class="paper-institutions">${join('; ', institutionElements)}</div>`
         : null;
 
+    const commentBadge = comment !== null
+        ? html`<span class="authors-comment">${comment}</span>`
+        : null;
+
     const container = html`
-        <div class="paper-authors-container">
+        <div class="paper-authors-container" style="position: relative">
+            ${commentBadge}
             <div class="paper-authors">${authorNodes}</div>
             ${institutionsHtml}
         </div>

--- a/src/paperoni/web/assets/style.css
+++ b/src/paperoni/web/assets/style.css
@@ -1839,6 +1839,14 @@ body {
     margin-bottom: 10px;
 }
 
+.authors-comment {
+    position: absolute;
+    top: 0;
+    right: 0;
+    font-size: 11px;
+    color: #999;
+}
+
 .paper-authors {
     color: #555;
     margin-bottom: 5px;

--- a/src/paperoni/web/assets/workset.js
+++ b/src/paperoni/web/assets/workset.js
@@ -530,7 +530,27 @@ async function fetchWorksets(offset = 0, size = 100) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
-    return await response.json();
+    const data = await response.json();
+    return transformComments(data);
+}
+
+function transformComments(obj) {
+    if (Array.isArray(obj)) {
+        return obj.map(transformComments);
+    } else if (obj !== null && typeof obj === 'object') {
+        if ('$value' in obj && '$comment' in obj) {
+            const value = obj.$value;
+            const comment = obj.$comment;
+            if (value !== null && typeof value === 'object') {
+                let tvalue = transformComments(value);
+                tvalue.$comment = comment;
+                return tvalue;
+            }
+            return value;
+        }
+        return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, transformComments(v)]));
+    }
+    return obj;
 }
 
 function createInfoValue(value) {

--- a/src/paperoni/web/restapi.py
+++ b/src/paperoni/web/restapi.py
@@ -557,13 +557,13 @@ def install_api(app) -> FastAPI:
             total=len(work.top),
         )
 
-    @app.get(
+    @app.post(
         f"{prefix}/work/include",
         response_model=IncludeResponse,
         dependencies=[Depends(hascap("admin"))],
     )
     async def work_include_papers(request: IncludeRequest):
-        """Search for papers in the collection."""
+        """Include papers from the workset."""
         work = Work(command=request, work_file=config.work_file)
 
         added = await work.run()

--- a/src/paperoni/web/restapi.py
+++ b/src/paperoni/web/restapi.py
@@ -10,7 +10,7 @@ from typing import Any, Generator, Iterable, Literal
 
 from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.responses import StreamingResponse
-from serieux import auto_singleton, deserialize, serialize
+from serieux import CommentRec, auto_singleton, deserialize, serialize
 
 from ..__main__ import Coll, Focus, Formatter, Fulltext, Work, expand_paper_links
 from ..config import config
@@ -546,10 +546,12 @@ def install_api(app) -> FastAPI:
         request: ViewRequest = Depends(), user: str = Depends(hascap("admin"))
     ):
         work = Work(command=request, work_file=config.work_file)
-        worksets: list[Scored[PaperWorkingSet]] = list(request.slice(await work.run()))
+        worksets: list[Scored[CommentRec[PaperWorkingSet, float]]] = list(
+            request.slice(await work.run())
+        )
 
         return ViewResponse(
-            results=serialize(list[Scored[PaperWorkingSet]], worksets),
+            results=serialize(list[Scored[CommentRec[PaperWorkingSet, float]]], worksets),
             count=request.count,
             next_offset=request.next_offset,
             total=len(work.top),

--- a/terraform/job-scrape-all.tf
+++ b/terraform/job-scrape-all.tf
@@ -1,0 +1,115 @@
+
+##################
+# Scrape-all Job #
+##################
+
+resource "google_cloud_run_v2_job_iam_member" "paperoni_scrape_all_invoker" {
+  name     = google_cloud_run_v2_job.paperoni_scrape_all.name
+  location = google_cloud_run_v2_job.paperoni_scrape_all.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${data.google_project.paperoni.number}-compute@developer.gserviceaccount.com"
+}
+
+resource "google_cloud_run_v2_job" "paperoni_scrape_all" {
+  name     = "${var.prefix}-scrape-all"
+  location = var.google_region
+
+  template {
+    template {
+      service_account = google_service_account.paperoni_user.email
+      timeout         = "36000s" # 10 hours
+
+      containers {
+        image   = "gcr.io/cloudrun/hello"
+        command = ["scrape_all"]
+
+        resources {
+          limits = {
+            memory = "4Gi"
+          }
+        }
+
+        env {
+          name  = "GIFNOC_FILE"
+          value = "/paperoni-config/paperoni.yaml"
+        }
+
+        env {
+          name = "SERIEUX_PASSWORD"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.serieux_password.id
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name  = "MONGODB_NAME"
+          value = google_firestore_database.paperoni_db.name
+        }
+
+        env {
+          name  = "MONGODB_CONNECTION"
+          value = local.mongo_uri
+        }
+
+        env {
+          name  = "INSTANCE_PREFIX"
+          value = var.prefix
+        }
+
+        volume_mounts {
+          name       = "gcs_cache"
+          mount_path = "/paperoni-cache"
+        }
+
+        volume_mounts {
+          name       = "gcs_config"
+          mount_path = "/paperoni-config"
+        }
+      }
+
+      volumes {
+        name = "gcs_cache"
+        gcs {
+          bucket    = google_storage_bucket.paperoni_cache.name
+          read_only = false
+        }
+      }
+
+      volumes {
+        name = "gcs_config"
+        gcs {
+          bucket    = google_storage_bucket.paperoni_config.name
+          read_only = false
+        }
+      }
+    }
+  }
+  lifecycle { ignore_changes = [template[0].template[0].containers[0].image] }
+  deletion_protection = false
+}
+
+resource "google_cloud_scheduler_job" "paperoni_scrape_all_regular" {
+  name             = "${var.prefix}-scrape-all-regular"
+  description      = "Execute paperoni scrape-all job"
+  schedule         = "0 3 * * 6"
+  time_zone        = var.timezone
+  region           = var.google_region
+  attempt_deadline = "60s"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.google_region}/jobs/${google_cloud_run_v2_job.paperoni_scrape_all.name}:run"
+
+    oauth_token {
+      service_account_email = "${data.google_project.paperoni.number}-compute@developer.gserviceaccount.com"
+    }
+  }
+
+  depends_on = [
+    google_project_service.cloud_scheduler,
+    google_cloud_run_v2_job_iam_member.paperoni_scrape_all_invoker
+  ]
+}

--- a/terraform/job-scrape-recent.tf
+++ b/terraform/job-scrape-recent.tf
@@ -1,0 +1,115 @@
+
+#####################
+# Scrape-recent Job #
+#####################
+
+resource "google_cloud_run_v2_job_iam_member" "paperoni_scrape_recent_invoker" {
+  name     = google_cloud_run_v2_job.paperoni_scrape_recent.name
+  location = google_cloud_run_v2_job.paperoni_scrape_recent.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${data.google_project.paperoni.number}-compute@developer.gserviceaccount.com"
+}
+
+resource "google_cloud_run_v2_job" "paperoni_scrape_recent" {
+  name     = "${var.prefix}-scrape-recent"
+  location = var.google_region
+
+  template {
+    template {
+      service_account = google_service_account.paperoni_user.email
+      timeout         = "36000s" # 10 hours
+
+      containers {
+        image   = "gcr.io/cloudrun/hello"
+        command = ["scrape_recent"]
+
+        resources {
+          limits = {
+            memory = "4Gi"
+          }
+        }
+
+        env {
+          name  = "GIFNOC_FILE"
+          value = "/paperoni-config/paperoni.yaml"
+        }
+
+        env {
+          name = "SERIEUX_PASSWORD"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.serieux_password.id
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name  = "MONGODB_NAME"
+          value = google_firestore_database.paperoni_db.name
+        }
+
+        env {
+          name  = "MONGODB_CONNECTION"
+          value = local.mongo_uri
+        }
+
+        env {
+          name  = "INSTANCE_PREFIX"
+          value = var.prefix
+        }
+
+        volume_mounts {
+          name       = "gcs_cache"
+          mount_path = "/paperoni-cache"
+        }
+
+        volume_mounts {
+          name       = "gcs_config"
+          mount_path = "/paperoni-config"
+        }
+      }
+
+      volumes {
+        name = "gcs_cache"
+        gcs {
+          bucket    = google_storage_bucket.paperoni_cache.name
+          read_only = false
+        }
+      }
+
+      volumes {
+        name = "gcs_config"
+        gcs {
+          bucket    = google_storage_bucket.paperoni_config.name
+          read_only = false
+        }
+      }
+    }
+  }
+  lifecycle { ignore_changes = [template[0].template[0].containers[0].image] }
+  deletion_protection = false
+}
+
+resource "google_cloud_scheduler_job" "paperoni_scrape_recent_regular" {
+  name             = "${var.prefix}-scrape-recent-regular"
+  description      = "Execute paperoni scrape-recent job"
+  schedule         = "0 3 * * 0"
+  time_zone        = var.timezone
+  region           = var.google_region
+  attempt_deadline = "60s"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.google_region}/jobs/${google_cloud_run_v2_job.paperoni_scrape_recent.name}:run"
+
+    oauth_token {
+      service_account_email = "${data.google_project.paperoni.number}-compute@developer.gserviceaccount.com"
+    }
+  }
+
+  depends_on = [
+    google_project_service.cloud_scheduler,
+    google_cloud_run_v2_job_iam_member.paperoni_scrape_recent_invoker
+  ]
+}

--- a/terraform/job-scrape-updates.tf
+++ b/terraform/job-scrape-updates.tf
@@ -1,0 +1,115 @@
+
+######################
+# Scrape-updates Job #
+######################
+
+resource "google_cloud_run_v2_job_iam_member" "paperoni_scrape_updates_invoker" {
+  name     = google_cloud_run_v2_job.paperoni_scrape_updates.name
+  location = google_cloud_run_v2_job.paperoni_scrape_updates.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${data.google_project.paperoni.number}-compute@developer.gserviceaccount.com"
+}
+
+resource "google_cloud_run_v2_job" "paperoni_scrape_updates" {
+  name     = "${var.prefix}-scrape-updates"
+  location = var.google_region
+
+  template {
+    template {
+      service_account = google_service_account.paperoni_user.email
+      timeout         = "36000s" # 10 hours
+
+      containers {
+        image   = "gcr.io/cloudrun/hello"
+        command = ["scrape_updates"]
+
+        resources {
+          limits = {
+            memory = "4Gi"
+          }
+        }
+
+        env {
+          name  = "GIFNOC_FILE"
+          value = "/paperoni-config/paperoni.yaml"
+        }
+
+        env {
+          name = "SERIEUX_PASSWORD"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.serieux_password.id
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name  = "MONGODB_NAME"
+          value = google_firestore_database.paperoni_db.name
+        }
+
+        env {
+          name  = "MONGODB_CONNECTION"
+          value = local.mongo_uri
+        }
+
+        env {
+          name  = "INSTANCE_PREFIX"
+          value = var.prefix
+        }
+
+        volume_mounts {
+          name       = "gcs_cache"
+          mount_path = "/paperoni-cache"
+        }
+
+        volume_mounts {
+          name       = "gcs_config"
+          mount_path = "/paperoni-config"
+        }
+      }
+
+      volumes {
+        name = "gcs_cache"
+        gcs {
+          bucket    = google_storage_bucket.paperoni_cache.name
+          read_only = false
+        }
+      }
+
+      volumes {
+        name = "gcs_config"
+        gcs {
+          bucket    = google_storage_bucket.paperoni_config.name
+          read_only = false
+        }
+      }
+    }
+  }
+  lifecycle { ignore_changes = [template[0].template[0].containers[0].image] }
+  deletion_protection = false
+}
+
+resource "google_cloud_scheduler_job" "paperoni_scrape_updates_regular" {
+  name             = "${var.prefix}-scrape-updates-regular"
+  description      = "Execute paperoni scrape-updates job"
+  schedule         = "0 3 * * 1"
+  time_zone        = var.timezone
+  region           = var.google_region
+  attempt_deadline = "60s"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.google_region}/jobs/${google_cloud_run_v2_job.paperoni_scrape_updates.name}:run"
+
+    oauth_token {
+      service_account_email = "${data.google_project.paperoni.number}-compute@developer.gserviceaccount.com"
+    }
+  }
+
+  depends_on = [
+    google_project_service.cloud_scheduler,
+    google_cloud_run_v2_job_iam_member.paperoni_scrape_updates_invoker
+  ]
+}

--- a/terraform/paperoni.tf
+++ b/terraform/paperoni.tf
@@ -178,13 +178,6 @@ resource "google_cloud_run_v2_service_iam_member" "paperoni_web_invoker" {
   member   = "allUsers"
 }
 
-resource "google_cloud_run_v2_job_iam_member" "paperoni_scrape_invoker" {
-  name     = google_cloud_run_v2_job.paperoni_scrape.name
-  location = google_cloud_run_v2_job.paperoni_scrape.location
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:${data.google_project.paperoni.number}-compute@developer.gserviceaccount.com"
-}
-
 ###################
 # Enable services #
 ###################
@@ -357,7 +350,31 @@ resource "google_cloudbuild_trigger" "paperoni_build_trigger" {
         "run",
         "jobs",
         "update",
-        "${var.prefix}-scrape",
+        "${var.prefix}-scrape-all",
+        "--region", "${var.google_region}",
+        "--image", "${google_artifact_registry_repository.paperoni_img.registry_uri}/paperoni:$COMMIT_SHA",
+      ]
+    }
+    step {
+      name       = "gcr.io/cloud-builders/gcloud"
+      entrypoint = "gcloud"
+      args = [
+        "run",
+        "jobs",
+        "update",
+        "${var.prefix}-scrape-recent",
+        "--region", "${var.google_region}",
+        "--image", "${google_artifact_registry_repository.paperoni_img.registry_uri}/paperoni:$COMMIT_SHA",
+      ]
+    }
+    step {
+      name       = "gcr.io/cloud-builders/gcloud"
+      entrypoint = "gcloud"
+      args = [
+        "run",
+        "jobs",
+        "update",
+        "${var.prefix}-scrape-updates",
         "--region", "${var.google_region}",
         "--image", "${google_artifact_registry_repository.paperoni_img.registry_uri}/paperoni:$COMMIT_SHA",
       ]
@@ -495,112 +512,4 @@ resource "google_cloud_run_v2_service" "paperoni_web" {
   }
   lifecycle { ignore_changes = [template[0].containers[0].image] }
   deletion_protection = false
-}
-
-##############
-# Scrape Job #
-##############
-
-resource "google_cloud_run_v2_job" "paperoni_scrape" {
-  name     = "${var.prefix}-scrape"
-  location = var.google_region
-
-  template {
-    template {
-      service_account = google_service_account.paperoni_user.email
-      timeout         = "36000s" # 10 hours
-
-      containers {
-        image   = "gcr.io/cloudrun/hello"
-        command = ["scrape"]
-
-        resources {
-          limits = {
-            memory = "4Gi"
-          }
-        }
-
-        env {
-          name  = "GIFNOC_FILE"
-          value = "/paperoni-config/paperoni.yaml"
-        }
-
-        env {
-          name = "SERIEUX_PASSWORD"
-          value_source {
-            secret_key_ref {
-              secret  = google_secret_manager_secret.serieux_password.id
-              version = "latest"
-            }
-          }
-        }
-
-        env {
-          name  = "MONGODB_NAME"
-          value = google_firestore_database.paperoni_db.name
-        }
-
-        env {
-          name  = "MONGODB_CONNECTION"
-          value = local.mongo_uri
-        }
-
-        env {
-          name  = "INSTANCE_PREFIX"
-          value = var.prefix
-        }
-
-        volume_mounts {
-          name       = "gcs_cache"
-          mount_path = "/paperoni-cache"
-        }
-
-        volume_mounts {
-          name       = "gcs_config"
-          mount_path = "/paperoni-config"
-        }
-      }
-
-      volumes {
-        name = "gcs_cache"
-        gcs {
-          bucket    = google_storage_bucket.paperoni_cache.name
-          read_only = false
-        }
-      }
-
-      volumes {
-        name = "gcs_config"
-        gcs {
-          bucket    = google_storage_bucket.paperoni_config.name
-          read_only = false
-        }
-      }
-    }
-  }
-  lifecycle { ignore_changes = [template[0].template[0].containers[0].image] }
-  deletion_protection = false
-}
-
-resource "google_cloud_scheduler_job" "paperoni_scrape_regular" {
-  name             = "${var.prefix}-scrape-regular"
-  description      = "Execute paperoni scrape job"
-  schedule         = "0 3 * * *"
-  time_zone        = var.timezone
-  region           = var.google_region
-  attempt_deadline = "60s"
-
-  http_target {
-    http_method = "POST"
-    uri         = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.google_region}/jobs/${google_cloud_run_v2_job.paperoni_scrape.name}:run"
-
-    oauth_token {
-      service_account_email = "${data.google_project.paperoni.number}-compute@developer.gserviceaccount.com"
-    }
-  }
-
-  depends_on = [
-    google_project_service.cloud_scheduler,
-    google_cloud_run_v2_job_iam_member.paperoni_scrape_invoker
-  ]
 }

--- a/tests/model/test_merge.py
+++ b/tests/model/test_merge.py
@@ -120,6 +120,26 @@ def test_merge_author_lists():
     ]
 
 
+def test_merge_author_lists_override():
+    p1 = PaperAuthor(
+        display_name="John",
+        author=Author(name="John", links=[Link(type="job", link="baker")]),
+    )
+    p2 = PaperAuthor(
+        display_name="John",
+        author=Author(name="John", links=[Link(type="hair", link="yes")]),
+    )
+    p3 = PaperAuthor(display_name="Gunther", author=Author(name="Gunther", links=[]))
+
+    l1 = [p3, p1]
+    l2 = [p2]
+
+    assert merge(qual(l1, 10), l2) == l1
+    assert merge(l1, qual(l2, 10)) == l2
+    assert merge(qual(l1, 100), qual(l2, 10)) == l1
+    assert merge(qual(l1, 10), qual(l2, 100)) == l2
+
+
 def test_merge_author_lists_similarity():
     p1 = PaperAuthor(
         display_name="J. Smith",


### PR DESCRIPTION
* Fix merging of papers when they both have high priority (one merge rule had the wrong priority).
* Show author list score in the workset interface (could be generalized further but I'm not sure how to display it nicely in a generic way). The API endpoint is accordingly modified to include the $comment fields.
* Define scraping jobs for recent papers and updates in Procfile and terraform, to limit variance about what we get each week
* Set force=true in add_papers; this is necessary for Suggest and I don't really see why we wouldn't also do that for Include
* Fix occasional bug in token counting when there are no thought tokens
