### PR TITLE
Improve and fix up the API documentation

### DIFF
--- a/src/paperoni/__main__.py
+++ b/src/paperoni/__main__.py
@@ -60,7 +60,15 @@ from .model.utils import should_reprocess, should_rerun
 from .refinement import fetch_all
 from .refinement.llm_normalize import normalize_paper
 from .richlog import ErrorOccurred, LogEvent, Logger, ProgressiveCount, Statistic
-from .utils import as_aiter, deprox, expand_links_dict, prog, soft_fail, url_to_id
+from .utils import (
+    as_aiter,
+    deprox,
+    expand_links_dict,
+    prog,
+    soft_fail,
+    split_include_exclude,
+    url_to_id,
+)
 
 
 def buche_available():
@@ -788,11 +796,11 @@ class Coll:
         # [alias --end]
         end_date: date = None
 
-        # Release status to match exactly; entries of the form "-preprint" are exclusions
+        # Release status to match exactly; prefix with "-" or "~" to exclude (e.g. "-preprint")
         # [alias: -s]
         status: list[str] = None
 
-        # Filter by flag; exclude a flag with "~flagname"
+        # Filter by flag; prefix with "-" or "~" to exclude (e.g. "~flagname")
         # [alias: -f]
         flags: set[str] = None
 
@@ -809,7 +817,7 @@ class Coll:
         offset: int = 0
 
         async def run(self, coll: "Coll") -> list[Paper]:
-            flags = set() if self.flags is None else self.flags
+            include_flags, exclude_flags = split_include_exclude(self.flags)
             papers = [
                 expand_paper_links(p) if self.expand_links else p
                 async for p in coll.collection.search(
@@ -822,8 +830,8 @@ class Coll:
                     start_date=self.start_date,
                     end_date=self.end_date,
                     status=self.status,
-                    include_flags={f for f in flags if not f.startswith("~")},
-                    exclude_flags={f[1:] for f in flags if f.startswith("~")},
+                    include_flags=set(include_flags),
+                    exclude_flags=set(exclude_flags),
                     limit=self.limit,
                     offset=self.offset,
                 )
@@ -832,7 +840,7 @@ class Coll:
             return papers
 
         async def count(self, coll: "Coll") -> int:
-            flags = set() if self.flags is None else self.flags
+            include_flags, exclude_flags = split_include_exclude(self.flags)
             return await coll.collection.count(
                 paper_id=self.paper_id,
                 title=self.title,
@@ -843,8 +851,8 @@ class Coll:
                 start_date=self.start_date,
                 end_date=self.end_date,
                 status=self.status,
-                include_flags={f for f in flags if not f.startswith("~")},
-                exclude_flags={f[1:] for f in flags if f.startswith("~")},
+                include_flags=set(include_flags),
+                exclude_flags=set(exclude_flags),
             )
 
     @dataclass

--- a/src/paperoni/__main__.py
+++ b/src/paperoni/__main__.py
@@ -764,7 +764,7 @@ class Coll:
         # Title of the paper
         title: str = None
 
-        # Author of the paper
+        # Author of the paper; use "=Author Name" for exact match (faster)
         # [alias: -a]
         author: str = None
 
@@ -788,24 +788,24 @@ class Coll:
         # [alias --end]
         end_date: date = None
 
-        # Release status to match exactly; entries of the form "-xyz" exclude
+        # Release status to match exactly; entries of the form "-preprint" are exclusions
         # [alias: -s]
         status: list[str] = None
 
-        # Flag search
+        # Filter by flag; exclude a flag with "~flagname"
         # [alias: -f]
         flags: set[str] = None
 
-        # Whether to expand links
+        # Whether to resolve the plain type:id metadata links into actual urls
         expand_links: bool = False
 
         # Output format
         format: Formatter = AutoFormatter
 
-        # Limit
+        # Maximum number of papers to output
         limit: int = 100
 
-        # Offset
+        # Number of papers to skip from the first one
         offset: int = 0
 
         async def run(self, coll: "Coll") -> list[Paper]:

--- a/src/paperoni/collection/memcoll.py
+++ b/src/paperoni/collection/memcoll.py
@@ -12,6 +12,7 @@ from ..utils import (
     normalize_title,
     normalize_topic,
     normalize_venue,
+    split_include_exclude,
     to_sync,
 )
 from .abc import PaperCollection
@@ -217,8 +218,7 @@ class MemCollection(PaperCollection):
         )
         venue_match = venue and _make_matcher(venue, normalize_venue)
         topic_matchers = [_make_matcher(t, normalize_topic) for t in topic or []]
-        include_status = [s for s in status or [] if not s.startswith("-")]
-        exclude_status = [s[1:] for s in status or [] if s.startswith("-")]
+        include_status, exclude_status = split_include_exclude(status)
         skipped = 0
         yielded = 0
         for p in self._index:

--- a/src/paperoni/collection/mongocoll.py
+++ b/src/paperoni/collection/mongocoll.py
@@ -25,6 +25,7 @@ from ..utils import (
     normalize_institution,
     normalize_name,
     normalize_title,
+    split_include_exclude,
     to_sync,
 )
 from .abc import PaperCollection
@@ -314,10 +315,9 @@ class MongoCollection(PaperCollection):
             release_match["venue.date"] = date_query
 
         # Status filtering: plain entries match the release peer-review status
-        # exactly (any of them), entries of the form "-xyz" require it to differ.
+        # exactly (any of them), entries of the form "-xyz"/"~xyz" require it to differ.
         if status:
-            include_status = [s for s in status if not s.startswith("-")]
-            exclude_status = [s[1:] for s in status if s.startswith("-")]
+            include_status, exclude_status = split_include_exclude(status)
             status_cond = {}
             if include_status:
                 status_cond["$in"] = include_status

--- a/src/paperoni/misc/newsletter.py
+++ b/src/paperoni/misc/newsletter.py
@@ -276,7 +276,7 @@ def latest_html(peers, preprints, lang):
 def install_latest(app):
     hascap = app.auth.get_email_capability
 
-    @app.get("/latest-group")
+    @app.get("/latest-group", include_in_schema=False)
     async def latest_group_page(
         request: Request,
         user: str = Depends(hascap("validate", redirect=True)),
@@ -294,14 +294,20 @@ def install_latest(app):
             help_section="/help/validation#latest-group",
         )
 
-    @app.get("/api/v1/latest", dependencies=[Depends(hascap("validate"))])
+    @app.get(
+        "/api/v1/latest", dependencies=[Depends(hascap("validate"))], tags=["Advanced"]
+    )
     async def get_latest(generator: LatestGenerator = Depends()):
         """Get latest papers using LatestGenerator."""
         coll = Coll(command=None)
         result = await generator(coll.collection)
         return serialize(dict[str, list[Paper]], result)
 
-    @app.post("/latest-group/generate", dependencies=[Depends(hascap("validate"))])
+    @app.post(
+        "/latest-group/generate",
+        dependencies=[Depends(hascap("validate"))],
+        include_in_schema=False,
+    )
     async def generate_latest(generator: LatestGenerator = Depends()):
         """Generate newsletter content from latest papers."""
         coll = Coll(command=None)

--- a/src/paperoni/utils.py
+++ b/src/paperoni/utils.py
@@ -10,6 +10,28 @@ from ovld import ovld, recurse
 from serieux.proxy import ProxyBase
 from unidecode import unidecode
 
+# Prefixes that mark a search token (status, flag, ...) as an exclusion.
+# "-" is convenient in the web UI; "~" is convenient on the CLI (where "-"
+# would be parsed as an option). Both are accepted everywhere.
+EXCLUDE_PREFIXES = "-~"
+
+
+def split_include_exclude(values, prefixes=EXCLUDE_PREFIXES):
+    """Split search tokens into (include, exclude) lists.
+
+    A token starting with any character in ``prefixes`` is an exclusion, with
+    that leading character stripped; every other token is an inclusion.
+    """
+    include = []
+    exclude = []
+    for value in values or []:
+        if value and value[0] in prefixes:
+            exclude.append(value[1:])
+        else:
+            include.append(value)
+    return include, exclude
+
+
 link_generators = {
     "arxiv": {
         "abstract": "https://arxiv.org/abs/{}",

--- a/src/paperoni/web/capabilities.py
+++ b/src/paperoni/web/capabilities.py
@@ -18,7 +18,7 @@ def install_capabilities(app: FastAPI) -> FastAPI:
     # Use user_management capability if available, otherwise fall back to admin
     required_cap = user_management_cap if user_management_cap else "admin"
 
-    @app.get("/capabilities")
+    @app.get("/capabilities", include_in_schema=False)
     async def capabilities_page(
         request: Request, user: str = Depends(hascap(required_cap, redirect=True))
     ):

--- a/src/paperoni/web/edit.py
+++ b/src/paperoni/web/edit.py
@@ -13,7 +13,7 @@ def install_edit(app: FastAPI) -> FastAPI:
 
     hascap = app.auth.get_email_capability
 
-    @app.get("/edit/{paper_id}")
+    @app.get("/edit/{paper_id}", include_in_schema=False)
     async def edit_page(
         request: Request,
         paper_id: int | str,

--- a/src/paperoni/web/focuses.py
+++ b/src/paperoni/web/focuses.py
@@ -12,7 +12,11 @@ def install_focuses(app: FastAPI) -> FastAPI:
 
     hascap = app.auth.get_email_capability
 
-    @app.get("/focuses", dependencies=[Depends(hascap("admin"))])
+    @app.get(
+        "/focuses",
+        dependencies=[Depends(hascap("admin"))],
+        include_in_schema=False,
+    )
     async def focuses_page(request: Request):
         """Render the focuses edit page."""
         return render_template(

--- a/src/paperoni/web/main.py
+++ b/src/paperoni/web/main.py
@@ -37,10 +37,33 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         return response
 
 
+_DESCRIPTION = """
+API for searching scientific papers and operate on Paperoni's database.
+
+To use this API:
+
+1. **Get a token**: [Click here](/token). Sign in with Google when
+   prompted. When the flow finishes, the page will show your token — copy it and
+   store it securely.
+
+2. **Use the token**: Send it in the `Authorization` header as
+   `Bearer YOUR_TOKEN`.
+
+Example — search (first 10 results):
+
+```
+curl -H 'Authorization: Bearer YOUR_TOKEN' 'https://paperoni.mila.quebec/api/v1/search?limit=10&offset=0'
+```
+
+Replace `YOUR_TOKEN` with the token you copied and adjust the base URL if you
+use a different Paperoni instance.
+"""
+
+
 def create_app():
     app = FastAPI(
         title="Paperoni API",
-        description="API for searching scientific papers",
+        description=_DESCRIPTION,
         version=importlib.metadata.version(paperoni.__name__),
         openapi_tags=[
             {

--- a/src/paperoni/web/main.py
+++ b/src/paperoni/web/main.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from easy_oauth import OAuthManager
 from fastapi import FastAPI, HTTPException
 from fastapi.exception_handlers import http_exception_handler
+from fastapi.openapi.utils import get_openapi
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -12,6 +13,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 import paperoni
 
 from ..config import config
+from .openapi_schemas import apply_serieux_schemas
 
 app_logger = logging.getLogger(__name__)
 
@@ -40,6 +42,16 @@ def create_app():
         title="Paperoni API",
         description="API for searching scientific papers",
         version=importlib.metadata.version(paperoni.__name__),
+        openapi_tags=[
+            {
+                "name": "Main API",
+                "description": "Standard endpoints: searching and suggesting",
+            },
+            {
+                "name": "Advanced",
+                "description": "Curation, admin and internal processes.",
+            },
+        ],
     )
 
     @app.exception_handler(Exception)
@@ -66,5 +78,22 @@ def create_app():
     for entry_point in importlib.metadata.entry_points(group="paperoni.web"):
         func = entry_point.load()
         func(app)
+
+    def custom_openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+        openapi_schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+            tags=app.openapi_tags,
+        )
+        # Swap serieux-derived schemas in for endpoints that registered one.
+        apply_serieux_schemas(openapi_schema)
+        app.openapi_schema = openapi_schema
+        return openapi_schema
+
+    app.openapi = custom_openapi
 
     return app

--- a/src/paperoni/web/openapi_schemas.py
+++ b/src/paperoni/web/openapi_schemas.py
@@ -1,0 +1,113 @@
+"""Bridge serieux-generated JSON schemas into the FastAPI/OpenAPI docs.
+
+FastAPI/pydantic infers schemas from type hints but does not pick up the
+inline ``# comment`` field docs that serieux uses. For endpoints where the
+serieux schema is richer (parameter descriptions, formats, etc.), register the
+serieux type here and it will replace the auto-generated schema for that
+operation:
+
+- ``use_query_schema`` for GET-style query parameters.
+- ``use_body_schema`` for POST/PUT/DELETE JSON request bodies.
+
+``apply_serieux_schemas`` is called from the app's custom ``openapi()`` and
+rewrites every registered operation.
+"""
+
+import warnings
+
+from fastapi.encoders import jsonable_encoder
+from serieux import schema
+
+# (path, http_method) -> serieux type whose compiled schema documents the
+# operation's query parameters.
+_QUERY_PARAM_SCHEMAS: dict[tuple[str, str], type] = {}
+
+# (path, http_method) -> serieux type whose compiled schema documents the
+# operation's JSON request body.
+_BODY_SCHEMAS: dict[tuple[str, str], type] = {}
+
+
+def use_query_schema(path: str, method: str, typ: type) -> None:
+    """Register a serieux type as the query-parameter docs for an operation."""
+    _QUERY_PARAM_SCHEMAS[(path, method.lower())] = typ
+
+
+def use_body_schema(path: str, method: str, typ: type) -> None:
+    """Register a serieux type as the JSON request-body docs for an operation."""
+    _BODY_SCHEMAS[(path, method.lower())] = typ
+
+
+def _compiled(typ: type) -> dict:
+    """Compile a serieux schema with everything inlined, minus JSON-Schema meta keys."""
+    # ref_policy="never" inlines all $ref so the schema is self-contained; OpenAPI
+    # tooling does not resolve serieux's internal (non-#/components) refs.
+    compiled = schema(typ).compile(ref_policy="never")
+    compiled.pop("$schema", None)
+    # serieux embeds raw Python default values (timedelta, date, ...); make them
+    # JSON-native so the OpenAPI document stays serializable.
+    return jsonable_encoder(compiled)
+
+
+def _to_query_parameters(typ: type) -> list[dict]:
+    """Turn a serieux object schema into a list of OpenAPI query parameters."""
+    compiled = _compiled(typ)
+    required = set(compiled.get("required", []))
+
+    parameters = []
+    for name, prop in compiled.get("properties", {}).items():
+        prop = dict(prop)
+        # In OpenAPI, a parameter's description lives on the parameter, not its schema.
+        description = prop.pop("description", None)
+        parameter = {
+            "name": name,
+            "in": "query",
+            "required": name in required,
+            "schema": prop,
+        }
+        if description:
+            parameter["description"] = description
+        parameters.append(parameter)
+    return parameters
+
+
+def apply_serieux_schemas(openapi_schema: dict) -> None:
+    """Rewrite registered operations' params/bodies with serieux-derived schemas.
+
+    A type serieux cannot compile (e.g. a bare ``dict`` field) is skipped with a
+    warning, leaving FastAPI's inferred schema in place rather than breaking the
+    whole document.
+    """
+    paths = openapi_schema.get("paths", {})
+
+    for (path, method), typ in _QUERY_PARAM_SCHEMAS.items():
+        operation = paths.get(path, {}).get(method)
+        if operation is None:
+            continue
+        try:
+            parameters = _to_query_parameters(typ)
+        except Exception as exc:  # noqa: BLE001 — never let docs generation fail
+            warnings.warn(
+                f"serieux query schema for {method.upper()} {path} failed: {exc}"
+            )
+            continue
+        # Keep any path/header/cookie params FastAPI generated; swap out query ones.
+        kept = [p for p in operation.get("parameters", []) if p.get("in") != "query"]
+        operation["parameters"] = kept + parameters
+
+    for (path, method), typ in _BODY_SCHEMAS.items():
+        operation = paths.get(path, {}).get(method)
+        if operation is None:
+            continue
+        try:
+            body_schema = _compiled(typ)
+        except Exception as exc:  # noqa: BLE001 — never let docs generation fail
+            warnings.warn(
+                f"serieux body schema for {method.upper()} {path} failed: {exc}"
+            )
+            continue
+        # Preserve FastAPI's requestBody envelope (required flag, other media types)
+        # and only replace the application/json schema.
+        request_body = operation.setdefault("requestBody", {})
+        content = request_body.setdefault("content", {})
+        json_content = content.setdefault("application/json", {})
+        json_content["schema"] = body_schema

--- a/src/paperoni/web/operate.py
+++ b/src/paperoni/web/operate.py
@@ -14,6 +14,7 @@ from ..__main__ import Coll
 from ..config import config
 from ..operations import from_code
 from .helpers import render_template
+from .openapi_schemas import use_body_schema
 from .restapi import DiffResponse, PaperDiff, SearchRequest
 
 
@@ -40,7 +41,7 @@ def install_operate(app: FastAPI) -> FastAPI:
     hascap = app.auth.get_email_capability
     prefix = "/api/v1"
 
-    @app.get("/operate")
+    @app.get("/operate", include_in_schema=False)
     async def operate_page(
         request: Request,
         user: str = Depends(hascap("admin", redirect=True)),
@@ -65,6 +66,7 @@ def install_operate(app: FastAPI) -> FastAPI:
         f"{prefix}/operate",
         response_model=OperateResponse,
         dependencies=[Depends(hascap("admin"))],
+        tags=["Advanced"],
     )
     async def operate_papers_post(request: OperateRequest):
         try:
@@ -135,5 +137,7 @@ def install_operate(app: FastAPI) -> FastAPI:
                 status_code=500,
                 detail=traceback.format_exc(),
             )
+
+    use_body_schema(f"{prefix}/operate", "post", OperateRequest)
 
     return app

--- a/src/paperoni/web/pages.py
+++ b/src/paperoni/web/pages.py
@@ -137,7 +137,11 @@ def install_pages(app: FastAPI) -> FastAPI:
             return handler
 
         app.add_api_route(
-            mount, make_handler(), methods=["GET"], dependencies=dependencies
+            mount,
+            make_handler(),
+            methods=["GET"],
+            dependencies=dependencies,
+            include_in_schema=False,
         )
 
     return app

--- a/src/paperoni/web/reports.py
+++ b/src/paperoni/web/reports.py
@@ -14,7 +14,11 @@ def install_reports(app: FastAPI) -> FastAPI:
 
     hascap = app.auth.get_email_capability
 
-    @app.get("/logs/{path:path}", dependencies=[Depends(hascap("dev"))])
+    @app.get(
+        "/logs/{path:path}",
+        dependencies=[Depends(hascap("dev"))],
+        include_in_schema=False,
+    )
     async def route_logs(path: str):
         logs_dir = (config.data_path / "logs").resolve()
         report_path = (logs_dir / path).resolve()
@@ -30,7 +34,11 @@ def install_reports(app: FastAPI) -> FastAPI:
 
         return FileResponse(report_path)
 
-    @app.get("/report/{path:path}", dependencies=[Depends(hascap("dev"))])
+    @app.get(
+        "/report/{path:path}",
+        dependencies=[Depends(hascap("dev"))],
+        include_in_schema=False,
+    )
     async def route_report(request: Request, path: str):
         if not path:
             logs_dir = (config.data_path / "logs").resolve()

--- a/src/paperoni/web/restapi.py
+++ b/src/paperoni/web/restapi.py
@@ -22,6 +22,7 @@ from ..model.merge import PaperWorkingSet, merge_all
 from ..refinement import fetch_all
 from ..refinement.fetch import AnyOf
 from ..utils import url_to_id
+from .openapi_schemas import use_body_schema, use_query_schema
 
 # Tracks which users (by email) currently have a form-populate request running,
 # so that each user can only run one populate at a time.
@@ -284,6 +285,14 @@ class PaperIncludeRequest:
 
 
 @dataclass
+class _SerieuxPaperIncludeRequest:
+    """Request model for including new papers."""
+
+    papers: list[_Paper]
+    comment: str = ""
+
+
+@dataclass
 class PaperIncludeResponse:
     """Response model for including new papers."""
 
@@ -419,7 +428,7 @@ def install_api(app) -> FastAPI:
 
     hascap = app.auth.get_email_capability
 
-    @app.get(f"{prefix}")
+    @app.get(f"{prefix}", tags=["Main API"])
     async def root():
         """Root endpoint with API information."""
         return {
@@ -448,6 +457,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/search",
         response_model=SearchResponse,
         dependencies=[Depends(hascap("search"))],
+        tags=["Main API"],
     )
     async def search_papers(request: SearchRequest = Depends(parse_search_request)):
         """Search for papers in the collection."""
@@ -466,6 +476,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/pending/list",
         response_model=DiffResponse,
         dependencies=[Depends(hascap("search"))],
+        tags=["Main API"],
     )
     async def pending_papers(request: SearchRequest = Depends(parse_search_request)):
         if config.suggestions is None:
@@ -506,9 +517,15 @@ def install_api(app) -> FastAPI:
         f"{prefix}/pending/decide",
         response_model=PendingDecideResponse,
         dependencies=[Depends(hascap("search"))],
+        tags=["Advanced"],
     )
     async def pending_decide(request: PendingDecideRequest):
-        """Approve papers (add to collection) or reject them. Both are removed from suggestions."""
+        """Approve papers (add to collection) or reject them. Both are removed from
+        suggestions.
+
+        Both `approve` and `reject` are lists of paper IDs. Note that multiple edits
+        to the same paper operate on the same suggestion in the suggestions database.
+        """
         if config.suggestions is None:
             return PendingDecideResponse(
                 success=False,
@@ -551,6 +568,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/paper/{{paper_id}}",
         response_model=Paper,
         dependencies=[Depends(hascap("search"))],
+        tags=["Main API"],
     )
     async def get_paper(paper_id: str, latest_edit: bool = False):
         """Get a single paper by ID."""
@@ -568,7 +586,7 @@ def install_api(app) -> FastAPI:
         # FastAPI requires this conversion, it'll be serialized so it's fine
         return Paper(**vars(paper))
 
-    @app.post(f"{prefix}/work/add", response_model=AddResponse)
+    @app.post(f"{prefix}/work/add", response_model=AddResponse, tags=["Advanced"])
     async def work_add_papers(request: AddRequest, user: str = Depends(hascap("admin"))):
         request.user = user
 
@@ -577,7 +595,7 @@ def install_api(app) -> FastAPI:
 
         return AddResponse(total=len(work.top))
 
-    @app.get(f"{prefix}/work/view", response_model=ViewResponse)
+    @app.get(f"{prefix}/work/view", response_model=ViewResponse, tags=["Advanced"])
     async def work_view_papers(
         request: ViewRequest = Depends(), user: str = Depends(hascap("admin"))
     ):
@@ -597,6 +615,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/work/include",
         response_model=IncludeResponse,
         dependencies=[Depends(hascap("admin"))],
+        tags=["Advanced"],
     )
     async def work_include_papers(request: IncludeRequest):
         """Include papers from the workset."""
@@ -610,6 +629,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/set_flag",
         response_model=SetFlagResponse,
         dependencies=[Depends(hascap("admin"))],
+        tags=["Advanced"],
     )
     async def set_flag(request: SetFlagRequest):
         """Set a flag on a paper in the collection."""
@@ -637,6 +657,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/include",
         response_model=PaperIncludeResponse,
         dependencies=[Depends(hascap("validate"))],
+        tags=["Advanced"],
     )
     async def include_papers(request: PaperIncludeRequest):
         """Include papers in the collection."""
@@ -662,11 +683,17 @@ def install_api(app) -> FastAPI:
                 count=0,
             )
 
-    @app.post(f"{prefix}/suggest", response_model=PaperIncludeResponse)
+    @app.post(f"{prefix}/suggest", response_model=PaperIncludeResponse, tags=["Main API"])
     async def suggest_papers(
         request: PaperIncludeRequest, user: str = Depends(hascap("search"))
     ):
-        """Suggest papers to add/edit in the collection."""
+        """Suggest papers to add/edit in the collection.
+
+        Leave out a paper's `id` field to signal an addition.
+
+        To suggest a deletion, set the paper's ID, and include the "mark:delete" flag, e.g.
+        `{"papers": [{"id": PAPER_ID, "flags": ["mark:delete"]}]}`
+        """
         # Deserialize the papers from the request
         papers = deserialize(list[_Paper], request.papers)
         for p in papers:
@@ -690,7 +717,7 @@ def install_api(app) -> FastAPI:
                 count=0,
             )
 
-    @app.post(f"{prefix}/populate", response_model=PopulateResponse)
+    @app.post(f"{prefix}/populate", response_model=PopulateResponse, tags=["Main API"])
     async def populate_paper(
         request: PopulateRequest, user: str = Depends(hascap("search"))
     ):
@@ -728,12 +755,18 @@ def install_api(app) -> FastAPI:
         finally:
             _populate_in_progress.discard(user)
 
-    @app.get(f"{prefix}/focuses")
+    @app.get(
+        f"{prefix}/focuses",
+        dependencies=[Depends(hascap("search"))],
+        tags=["Advanced"],
+    )
     async def get_focuses():
         """Get the current configuration focuses with main and auto sublists."""
         return serialize(Focuses, config.focuses._obj)
 
-    @app.post(f"{prefix}/focuses", dependencies=[Depends(hascap("admin"))])
+    @app.post(
+        f"{prefix}/focuses", dependencies=[Depends(hascap("admin"))], tags=["Advanced"]
+    )
     async def set_focuses(new_focuses: dict):
         """Update the configuration focuses (main and auto sublists)."""
         if not hasattr(config.focuses, "save"):
@@ -750,6 +783,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/delete",
         response_model=DeletePapersResponse,
         dependencies=[Depends(hascap("validate"))],
+        tags=["Advanced"],
     )
     async def delete_papers(request: DeletePapersRequest):
         """Delete papers from the collection."""
@@ -765,6 +799,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/focus/auto",
         response_model=Focuses,
         dependencies=[Depends(hascap("admin"))],
+        tags=["Advanced"],
     )
     async def autofocus(request: AutoFocusRequest = Depends()):
         """Autofocus the collection."""
@@ -775,7 +810,8 @@ def install_api(app) -> FastAPI:
     @app.get(
         f"{prefix}/fulltext/locate",
         response_model=LocateFulltextResponse,
-        dependencies=[Depends(hascap("user"))],
+        dependencies=[Depends(hascap("search"))],
+        tags=["Advanced"],
     )
     async def locate_fulltext(request: LocateFulltextRequest):
         """Locate fulltext urls for a paper."""
@@ -790,7 +826,8 @@ def install_api(app) -> FastAPI:
 
     @app.get(
         f"{prefix}/fulltext/download",
-        dependencies=[Depends(hascap("user"))],
+        dependencies=[Depends(hascap("search"))],
+        tags=["Advanced"],
     )
     async def download_fulltext(request: DownloadFulltextRequest):
         """Download fulltext for a paper."""
@@ -814,6 +851,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/exclusions",
         response_model=ExclusionsListResponse,
         dependencies=[Depends(hascap("validate"))],
+        tags=["Advanced"],
     )
     async def list_exclusions(request: ExclusionsListRequest = Depends()):
         """List exclusions with pagination."""
@@ -834,6 +872,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/exclusions",
         response_model=AddExclusionsResponse,
         dependencies=[Depends(hascap("validate"))],
+        tags=["Advanced"],
     )
     async def add_exclusions(request: AddExclusionsRequest):
         """Add exclusions to the collection."""
@@ -850,6 +889,7 @@ def install_api(app) -> FastAPI:
         f"{prefix}/exclusions",
         response_model=RemoveExclusionsResponse,
         dependencies=[Depends(hascap("validate"))],
+        tags=["Advanced"],
     )
     async def remove_exclusions(request: RemoveExclusionsRequest):
         """Remove exclusions from the collection."""
@@ -861,5 +901,25 @@ def install_api(app) -> FastAPI:
             message=f"Removed {removed} exclusion(s)",
             count=removed,
         )
+
+    # Document requests from their serieux schemas (which carry the field
+    # descriptions from the inline comments) instead of the pydantic inference.
+    use_query_schema(f"{prefix}/search", "get", SearchRequest)
+    use_query_schema(f"{prefix}/pending/list", "get", SearchRequest)
+    use_query_schema(f"{prefix}/work/view", "get", ViewRequest)
+    use_query_schema(f"{prefix}/focus/auto", "post", AutoFocusRequest)
+
+    use_body_schema(f"{prefix}/suggest", "post", _SerieuxPaperIncludeRequest)
+    use_body_schema(f"{prefix}/populate", "post", _SerieuxPaperIncludeRequest)
+    use_body_schema(f"{prefix}/pending/decide", "post", PendingDecideRequest)
+    use_body_schema(f"{prefix}/work/include", "post", IncludeRequest)
+    use_body_schema(f"{prefix}/set_flag", "post", SetFlagRequest)
+    use_body_schema(f"{prefix}/focuses", "post", Focuses)
+    use_body_schema(f"{prefix}/delete", "post", DeletePapersRequest)
+    use_body_schema(f"{prefix}/exclusions", "post", AddExclusionsRequest)
+    use_body_schema(f"{prefix}/exclusions", "delete", RemoveExclusionsRequest)
+    # Not registered: /work/add, /include, /suggest, /populate — their bodies
+    # have untyped `dict`/`list[dict]` fields that serieux cannot schema (and
+    # which FastAPI already renders as a generic object).
 
     return app

--- a/src/paperoni/web/search.py
+++ b/src/paperoni/web/search.py
@@ -13,7 +13,7 @@ def install_search(app: FastAPI) -> FastAPI:
 
     hascap = app.auth.get_email_capability
 
-    @app.get("/search")
+    @app.get("/search", include_in_schema=False)
     async def search_page(
         request: Request,
         user: str = Depends(hascap("search", redirect=True)),
@@ -32,7 +32,7 @@ def install_search(app: FastAPI) -> FastAPI:
             help_section="/help#search",
         )
 
-    @app.get("/pending")
+    @app.get("/pending", include_in_schema=False)
     async def pending_page(
         request: Request,
         user: str = Depends(hascap("search", redirect=True)),
@@ -42,7 +42,7 @@ def install_search(app: FastAPI) -> FastAPI:
             "pending.html", request, help_section="/help/validation#pending"
         )
 
-    @app.get("/workset")
+    @app.get("/workset", include_in_schema=False)
     async def workset_page(
         request: Request,
         user: str = Depends(hascap("admin", redirect=True)),
@@ -57,7 +57,11 @@ def install_search(app: FastAPI) -> FastAPI:
             help_section="/help/admin#workset",
         )
 
-    @app.get("/exclusions", dependencies=[Depends(hascap("validate", redirect=True))])
+    @app.get(
+        "/exclusions",
+        dependencies=[Depends(hascap("validate", redirect=True))],
+        include_in_schema=False,
+    )
     async def exclusions_page(request: Request):
         """Render the exclusions management page."""
         return render_template(


### PR DESCRIPTION
* Remove UI endpoints from `/docs`
* Categorize endpoints into Main API and Advanced
* Use serieux to create the schemas, because serieux can get the parameter docs from the comments
